### PR TITLE
Add OpenRC manpages

### DIFF
--- a/man3/einfo.3
+++ b/man3/einfo.3
@@ -1,0 +1,197 @@
+.\" Copyright (c) 2007-2015 The OpenRC Authors.
+.\" See the Authors file at the top-level directory of this distribution and
+.\" https://github.com/OpenRC/openrc/blob/master/AUTHORS
+.\"
+.\" This file is part of OpenRC. It is subject to the license terms in
+.\" the LICENSE file found in the top-level directory of this
+.\" distribution and at https://github.com/OpenRC/openrc/blob/master/LICENSE
+.\" This file may not be copied, modified, propagated, or distributed
+.\"    except according to the terms contained in the LICENSE file.
+.\"
+.Dd Mar 16, 2008
+.Dt EINFO 3 SMM
+.Os OpenRC
+.Sh NAME
+.Nm einfo , ewarn , eerror , ebegin ,
+.Nm einfon , ewarnn , eerrorn , ebeginn ,
+.Nm einfov , ewarnv , ebeginv ,
+.Nm einfovn , ewarnvn , ebeginvn ,
+.Nm ewarnx , eerrorx ,
+.Nm eend , ewend ,
+.Nm eendv , ewendv ,
+.Nm ebracket ,
+.Nm eindent , eoutdent ,
+.Nm eindentv , eoutdentv ,
+.Nm eprefix
+.Nd colorful informational output
+.Sh LIBRARY
+Enhanced Information output library (libeinfo, -leinfo)
+.Sh SYNOPSIS
+.In einfo.h
+.Ft int Fn einfo "const char * restrict format" ...
+.Ft int Fn ewarn "const char * restrict format" ...
+.Ft int Fn eerror "const char * restrict format" ...
+.Ft int Fn ebegin "const char * restrict format" ...
+.Ft int Fn einfon "const char * restrict format" ...
+.Ft int Fn ewarnn "const char * restrict format" ...
+.Ft int Fn eerrorn "const char * restrict format" ...
+.Ft int Fn ebeginn "const char * restrict format" ...
+.Ft int Fn einfov "const char * restrict format" ...
+.Ft int Fn ewarnv "const char * restrict format" ...
+.Ft int Fn ebeginv "const char * restrict format" ...
+.Ft int Fn einfovn "const char * restrict format" ...
+.Ft int Fn ewarnvn "const char * restrict format" ...
+.Ft int Fn ebeginvn "const char * restrict format" ...
+.Ft int Fn ewarnx "const char * restrict format" ...
+.Ft int Fn eerrorx "const char * restrict format" ...
+.Ft int Fn eend "int retval" "const char * restrict format" ...
+.Ft int Fn ewend "int retval" "const char * restrict format" ...
+.Ft int Fn eendv "int retval" "const char * restrict format" ...
+.Ft int Fn ewendv "int retval" "const char * restrict format" ...
+.Ft void Fn ebracket "int col" "ECOLOR color" "const char * restrict msg"
+.Ft void Fn eindent void
+.Ft void Fn eoutdent void
+.Ft void Fn eindentv void
+.Ft void Fn eoutdentv void
+.Ft void Fn eprefix "const char * prefix"
+.Sh DESCRIPTION
+The
+.Fn einfo
+family of functions provide a simple informational output that is colorised.
+Basically
+.Fn einfo ,
+.Fn ewarn
+and
+.Fn eerror
+behave exactly like
+.Fn printf
+but prefix the output with a colored *. The function called denotes the color
+used with
+.Fn einfo
+being green,
+.Fn ewarn
+being yellow and
+.Fn eerror
+being red.
+einfo goes to stdout and the others go to stderr.
+The number of real characters printed is returned.
+.Fn ebegin
+is identical to
+.Fn einfo
+except that 3 dots are appended to the output.
+.Pp
+.Fn einfov ,
+.Fn ewarnv
+and
+.Fn ebeginv
+work the same way to
+.Fn einfo ,
+.Fn ewarn ,
+and
+.Fn ebegin
+respectively, but only work when
+.Va EINFO_VERBOSE
+is true. You can also make the
+.Fn einfo ,
+.Fn ewarn ,
+and
+.Fn ebegin
+functions silent by setting
+.Va EINFO_QUIET
+to true.
+.Pp
+These functions are designed to output a whole line, so they also
+append a newline to the string. To stop this behaviour, you can use the
+functions
+.Fn einfon ,
+.Fn ewarnn ,
+.Fn eerrorn ,
+.Fn einfovn ,
+.Fn ewarnvn ,
+and
+.Fn ebeginvn .
+.Pp
+.Fn eend ,
+.Fn ewend ,
+.Fn eendv
+and
+.Fn ewendv
+are the counterparts to the above functions. If
+.Fa retval
+is zero then ok in green is printed in a bracket at the end of the prior
+line. Otherwise we print the formatted string using
+.Fn error
+(or
+.Fn ewarn
+if
+.Fn ewend
+is called) !! in red (or yellow if
+.Fn ewend
+is called) is printed in a bracket at the end of the line.
+The value of
+.Fa retval
+is returned.
+.Pp
+.Fn ebracket
+does the same as
+.Fn eend
+but prints
+.Fa msg
+instead of ok or !! in the color
+.Fa color
+at the column
+.Fa col .
+.Pp
+.Fn eindent
+indents subsequent calls to the above functions by 3 characters.
+.Fn eoutdent
+removes an
+.Fn eindent .
+.Fn eindentv
+and
+.Fn eoutdentv
+only work when
+.Va EINFO_VERBOSE
+is true.
+.Pp
+.Fn eprefix
+prefixes the string
+.Fa prefix
+to the above functions.
+.Sh IMPLEMENTATION NOTES
+einfo can optionally be linked against the
+.Lb libtermcap
+so that we can correctly query the connected console for our color and
+cursor escape codes.
+If not, then we have a hard coded list of terminals we know about that support
+the commonly used codes for color and cursor position.
+.Sh ENVIRONMENT
+.Va EINFO_QUIET
+when set to true makes the
+.Fn einfo
+and
+.Fn einfon
+family of functions quiet, so nothing is printed.
+.Va EERROR_QUIET
+when set to true makes the
+.Fn eerror
+and
+.Fn eerrorn
+family of functions quiet, so nothing is printed.
+.Pp
+.Va EINFO_VERBOSE
+when set to true makes the
+.Fn einfov
+and
+.Fn einfovn
+family of functions work, so they do print.
+.Sh FILES
+.Pa /etc/init.d/functions.sh
+is provided by OpenRC, which allows shell scripts to use the above functions.
+For historical reasons our verbose functions are prefixed with v instead of
+suffixed. So einfov becomes veinfo, einfovn becomes veinfon.
+Rinse and repeat for the other verbose functions.
+.Sh SEE ALSO
+.Xr printf 3 ,
+.Sh AUTHORS
+.An Roy Marples <roy@marples.name>

--- a/man3/rc_config.3
+++ b/man3/rc_config.3
@@ -1,0 +1,59 @@
+.\" Copyright (c) 2007-2015 The OpenRC Authors.
+.\" See the Authors file at the top-level directory of this distribution and
+.\" https://github.com/OpenRC/openrc/blob/master/AUTHORS
+.\"
+.\" This file is part of OpenRC. It is subject to the license terms in
+.\" the LICENSE file found in the top-level directory of this
+.\" distribution and at https://github.com/OpenRC/openrc/blob/master/LICENSE
+.\" This file may not be copied, modified, propagated, or distributed
+.\"    except according to the terms contained in the LICENSE file.
+.\"
+.Dd Mar 17, 2008
+.Dt RC_CONFIG 3 SMM
+.Os OpenRC
+.Sh NAME
+.Nm rc_config_list , rc_config_load , rc_config_value , rc_yesno
+.Nd functions to query OpenRC service configurations
+.Sh LIBRARY
+Run Command library (librc, -lrc)
+.Sh SYNOPSIS
+.In rc.h
+.Ft "RC_STRINGLIST *" Fn rc_config_list "const char *file"
+.Ft "RC_STRINGLIST *" Fn rc_config_load "const char *file"
+.Ft "char *" Fn rc_config_value "const char *const *list" "const char *entry"
+.Ft bool Fn rc_yesno "const char *value"
+.Sh DESCRIPTION
+These functions provide an easy means of querying OpenRC configuration files.
+.Pp
+.Fn rc_config_list
+returns a list of non comment lines in
+.Fa file .
+.Fn rc_config_load
+does the same, but attempts to parse the line as if it was
+a shell assignment.
+.Fn rc_config_value
+returns the value of
+.Fa entry
+found in
+.Fa list .
+.Pp
+Each list should be freed using
+.Fn rc_stringlist_free
+when done.
+.Pp
+.Fn rc_yesno
+returns if
+.Fa value
+is true, yes, on or 1 regardless of case, otherwise false.
+If
+.Fa value
+is also not false, no, off or 0 regardless of case then
+.Va errno
+is set to
+.Va EINVAL .
+.Sh SEE ALSO
+.Xr malloc 3 ,
+.Xr rc_stringlist_free 3 ,
+.Xr sh 1
+.Sh AUTHORS
+.An Roy Marples <roy@marples.name>

--- a/man3/rc_deptree.3
+++ b/man3/rc_deptree.3
@@ -1,0 +1,99 @@
+.\" Copyright (c) 2007-2015 The OpenRC Authors.
+.\" See the Authors file at the top-level directory of this distribution and
+.\" https://github.com/OpenRC/openrc/blob/master/AUTHORS
+.\"
+.\" This file is part of OpenRC. It is subject to the license terms in
+.\" the LICENSE file found in the top-level directory of this
+.\" distribution and at https://github.com/OpenRC/openrc/blob/master/LICENSE
+.\" This file may not be copied, modified, propagated, or distributed
+.\"    except according to the terms contained in the LICENSE file.
+.\"
+.Dd Mar 16, 2008
+.Dt RC_DEPTREE 3 SMM
+.Os OpenRC
+.Sh NAME
+.Nm rc_deptree_update , rc_deptree_update_needed , rc_deptree_load ,
+.Nm rc_deptree_depend , rc_deptree_depends , rc_deptree_order ,
+.Nm rc_deptree_free
+.Nd RC dependency tree functions
+.Sh LIBRARY
+Run Command library (librc, -lrc)
+.Sh SYNOPSIS
+.In rc.h
+.Ft bool Fn rc_deptree_update void
+.Ft bool Fn rc_deptree_update_needed void
+.Ft RC_DEPTREE Fn rc_deptree_load void
+.Ft "RC_STRINGLIST *" Fo rc_deptree_depend
+.Fa "const RC_DEPTREE *deptree"
+.Fa "const char *type"
+.Fa "const char *service"
+.Fc
+.Ft bool Fo rc_deptree_depends
+.Fa "const RC_DEPTREE *deptree"
+.Fa "const char *const *types"
+.Fa "const char *const *services"
+.Fa "const char *runlevel"
+.Fa "int options"
+.Fc
+.Ft "RC_STRINGLIST *" Fo rc_deptree_order
+.Fa "const RC_DEPTREE *deptree"
+.Fa "const char *runlevel"
+.Fa "int options"
+.Fc
+.Ft void Fn rc_deptree_free "RC_DEPTREE *deptree"
+.Sh DESCRIPTION
+These functions provide a means of querying the dependencies of OpenRC
+services.
+.Pp
+.Fn rc_deptree_update
+updates the service dependency tree, normally
+.Pa /lib/rc/init.d/deptree .
+.Fn rc_deptree_update_needed
+checks to see if the dependency tree needs updated based on the mtime of it
+compared to
+.Pa /etc/init.d ,
+.Pa /etc/conf.d ,
+.Pa /usr/local/etc/init.d ,
+.Pa /usr/local/etc/conf.d ,
+.Pa /etc/rc.conf
+and any files specified by a service.
+.Pp
+.Fn rc_deptree_load
+loads the deptree and returns a pointer to it which needs to be freed by
+.Fn rc_deptree_free
+when done.
+.Pp
+.Fn rc_deptree_depend ,
+.Fn rc_deptree_depends
+and
+.Fn rc_deptree_order
+return a list of services from the
+.Fa deptree
+based on the
+.Fa type
+or
+.Fa types
+of dependency.
+.Fa options
+can be a bitmask of
+.Va RC_DEP_TRACE
+and
+.Va RC_DEP_STRICT .
+.Va RC_DEP_TRACE
+follows each services dependencies right down to the first service needed and
+.Va RC_DEP_STRICT
+only lists services actually needed or in the
+.Va runlevel .
+.Sh IMPLEMENTATION NOTES
+Each function that returns
+.Fr "RC_STRINGLIST *"
+should be freed by calling
+.Fn rc_stringlist_free
+when done.
+.Sh SEE ALSO
+.Xr malloc 3 ,
+.Xr free 3 ,
+.Xr rc_stringlist_free 3 ,
+.Xr openrc-run 8
+.Sh AUTHORS
+.An Roy Marples <roy@marples.name>

--- a/man3/rc_find_pids.3
+++ b/man3/rc_find_pids.3
@@ -1,0 +1,56 @@
+.\" Copyright (c) 2007-2015 The OpenRC Authors.
+.\" See the Authors file at the top-level directory of this distribution and
+.\" https://github.com/OpenRC/openrc/blob/master/AUTHORS
+.\"
+.\" This file is part of OpenRC. It is subject to the license terms in
+.\" the LICENSE file found in the top-level directory of this
+.\" distribution and at https://github.com/OpenRC/openrc/blob/master/LICENSE
+.\" This file may not be copied, modified, propagated, or distributed
+.\"    except according to the terms contained in the LICENSE file.
+.\"
+.Dd Mar 17, 2008
+.Dt RC_FIND_PIDS 3 SMM
+.Os OpenRC
+.Sh NAME
+.Nm rc_find_pids
+.Nd finds the pids of processes that match the given criteria
+.Sh LIBRARY
+Run Command library (librc, -lrc)
+.Sh SYNOPSIS
+.In rc.h
+.Ft "RC_PIDLIST *" Fo rc_find_pids
+.Fa "const char *const *argv"
+.Fa "const char *cmd"
+.Fa "uid_t uid"
+.Fa "pid_t pid"
+.Fc
+.Sh DESCRIPTION
+.Fn rc_find_pids
+returns RC_PIDLIST, a structure based on the LIST macro from
+.Xr queue 3
+which contains all the pids found matching the given criteria.
+If
+.Fa pid
+is given then only that pid is returned if it is running. Otherise we check
+all instances of
+.Fa argv
+with a process name of
+.Fa cmd
+owned by
+.Fa uid ,
+all of which are optional.
+.Pp
+The returned list should be freed when done.
+.Sh IMPLEMENTATION NOTES
+On BSD systems we use
+.Lb libkvm
+and on Linux systems we use the
+.Pa /proc
+filesystem to find our processes.
+.Pp
+Each RC_PID should be freed in the list as well as the list itself when done.
+.Sh SEE ALSO
+.Xr free 3 ,
+.Xr queue 3
+.Sh AUTHORS
+.An Roy Marples <roy@marples.name>

--- a/man3/rc_plugin_hook.3
+++ b/man3/rc_plugin_hook.3
@@ -1,0 +1,37 @@
+.\" Copyright (c) 2007-2015 The OpenRC Authors.
+.\" See the Authors file at the top-level directory of this distribution and
+.\" https://github.com/OpenRC/openrc/blob/master/AUTHORS
+.\"
+.\" This file is part of OpenRC. It is subject to the license terms in
+.\" the LICENSE file found in the top-level directory of this
+.\" distribution and at https://github.com/OpenRC/openrc/blob/master/LICENSE
+.\" This file may not be copied, modified, propagated, or distributed
+.\"    except according to the terms contained in the LICENSE file.
+.\"
+.Dd Mar 16, 2008
+.Dt RC_PLUGIN_HOOK 3 SMM
+.Os OpenRC
+.Sh NAME
+.Nm rc_plugin_hook
+.Nd hooks plugins into OpenRC services
+.Sh LIBRARY
+Run Command library (librc, -lrc)
+.Sh SYNOPSIS
+.In rc.h
+.Ft int Fn rc_plugin_hook "RC_HOOK hook" "const char *name"
+.Sh DESCRIPTION
+.Fn rc_plugin_hook
+is called for each shareable object found in
+.Pa /lib/rc/plugins .
+.Fa hook
+is set to the hook running, and
+.Fa name
+is set to the name of the runlevel or name of the service.
+.Pp
+Plugins can affect the parent environment by writing NULL separated strings to
+.Va rc_environ_fd .
+.Sh SEE ALSO
+.Xr openrc 8 ,
+.Xr openrc-run 8
+.Sh AUTHORS
+.An Roy Marples <roy@marples.name>

--- a/man3/rc_runlevel.3
+++ b/man3/rc_runlevel.3
@@ -1,0 +1,52 @@
+.\" Copyright (c) 2007-2015 The OpenRC Authors.
+.\" See the Authors file at the top-level directory of this distribution and
+.\" https://github.com/OpenRC/openrc/blob/master/AUTHORS
+.\"
+.\" This file is part of OpenRC. It is subject to the license terms in
+.\" the LICENSE file found in the top-level directory of this
+.\" distribution and at https://github.com/OpenRC/openrc/blob/master/LICENSE
+.\" This file may not be copied, modified, propagated, or distributed
+.\"    except according to the terms contained in the LICENSE file.
+.\"
+.Dd Mar 16, 2008
+.Dt RC_RUNLEVEL 3 SMM
+.Os OpenRC
+.Sh NAME
+.Nm rc_runlevel_get , rc_runlevel_exists , rc_runlevel_list , rc_runlevel_set ,
+.Nm rc_runlevel_starting , rc_runlevel_stopping
+.Nd RC runlevel functions
+.Sh LIBRARY
+Run Command library (librc, -lrc)
+.Sh SYNOPSIS
+.In rc.h
+.Ft "char *" Fn rc_runlevel_get void
+.Ft bool Fn rc_runlevel_exists
+.Ft "RC_STRINGLIST *" Fn rc_runlevel_list void
+.Ft bool Fn rc_runlevel_set "const char *runlevel"
+.Ft bool Fn rc_runlevel_starting void
+.Ft bool Fn rc_runlevel_stopping void
+.Sh DESCRIPTION
+These functions provide a means of querying OpenRC to find out which runlevel
+we are in and what services are in which runlevel.
+.Sh IMPLEMENTATION NOTES
+Each function that returns
+.Fr "char *"
+returns a malloced NULL terminated string that should be freed when done.
+.Pp
+Each function that returns
+.Fr "RC_STRINGLIST *"
+should by freed by calling
+.Fn rc_stringlist_free
+when done.
+.Sh FILES
+.Pa /etc/init.d/functions.sh
+is provided by OpenRC, which allows shell scripts to use the above functions.
+For historical reasons our verbose functions are prefixed with v instead of
+suffixed. So einfov becomes veinfo, einfovn becomes veinfon.
+Rinse and repeat for the other verbose functions.
+.Sh SEE ALSO
+.Xr malloc 3 ,
+.Xr free 3
+.Xr rc_stringlist_free 3
+.Sh AUTHORS
+.An Roy Marples <roy@marples.name>

--- a/man3/rc_service.3
+++ b/man3/rc_service.3
@@ -1,0 +1,216 @@
+.\" Copyright (c) 2007-2015 The OpenRC Authors.
+.\" See the Authors file at the top-level directory of this distribution and
+.\" https://github.com/OpenRC/openrc/blob/master/AUTHORS
+.\"
+.\" This file is part of OpenRC. It is subject to the license terms in
+.\" the LICENSE file found in the top-level directory of this
+.\" distribution and at https://github.com/OpenRC/openrc/blob/master/LICENSE
+.\" This file may not be copied, modified, propagated, or distributed
+.\"    except according to the terms contained in the LICENSE file.
+.\"
+.Dd Mar 16, 2008
+.Dt RC_SERVICE 3 SMM
+.Os OpenRC
+.Sh NAME
+.Nm rc_service_add , rc_service_delete , rc_service_daemon_set ,
+.Nm rc_service_description , rc_service_exists , rc_service_in_runlevel ,
+.Nm rc_service_mark , rc_service_extra_commands , rc_service_plugable ,
+.Nm rc_service_resolve , rc_service_schedule_start , rc_services_scheduled_by ,
+.Nm rc_service_schedule_clear , rc_service_state ,
+.Nm rc_service_started_daemon , rc_service_value_get , rc_service_value_set ,
+.Nm rc_services_in_runlevel , rc_services_in_state , rc_services_scheduled ,
+.Nm rc_service_daemons_crashed
+.Nd functions to query OpenRC services
+.Sh LIBRARY
+Run Command library (librc, -lrc)
+.Sh SYNOPSIS
+.In rc.h
+.Ft bool Fn rc_service_add "const char *runlevel" "const char *service"
+.Ft bool Fn rc_service_delete "const char *runlevel" "const char *service"
+.Ft bool Fo rc_service_daemon_set
+.Fa "const char *service"
+.Fa "const char *exec"
+.Fa "const char *name"
+.Fa "const char *pidfile"
+.Fa "bool started"
+.Fc
+.Ft "char *" Fo rc_service_description
+.Fa "const char *service"
+.Fa "const char *option"
+.Fc
+.Ft bool Fn rc_service_exists "const char *service"
+.Ft bool Fn rc_service_in_runlevel "const char *service" "const char *runlevel"
+.Ft bool Fn rc_service_mark "const char *service" "RC_SERVICE state"
+.Ft "RC_STRINGLIST *" Fn rc_service_extra_commands "const char *service"
+.Ft bool Fn rc_service_plugable "const char *service"
+.Ft "char *" rc_service_resolve "const char *service"
+.Ft bool Fo rc_service_schedule_start
+.Fa "const char *service"
+.Fa "const char *service_to_start"
+.Fc
+.Ft "RC_STRINGLIST *" Fn rc_services_scheduled_by "const char *service"
+.Ft bool Fn rc_service_schedule_clear "const char *service"
+.Ft RC_SERVICE Fn rc_service_state "const char *service"
+.Ft bool Fo rc_service_started_daemon
+.Fa "const char *service"
+.Fa "const char *exec"
+.Fa "int indx"
+.Fc
+.Ft "char *" Fn rc_service_value_get "const char *service" "const char *option"
+.Ft bool Fo rc_service_value_set
+.Fa "const char *service"
+.Fa "const char *option"
+.Fa "const char *value"
+.Fc
+.Ft "RC_STRINGLIST *" Fn rc_services_in_runlevel "const char *runlevel"
+.Ft "RC_STRINGLIST *" Fn rc_services_in_state "RC_SERVICE state"
+.Ft "RC_STRINGLIST *" Fn rc_services_scheduled "const char *service"
+.Ft bool Fn rc_service_daemons_crashed "const char *service"
+.Sh DESCRIPTION
+These functions provide a means of querying OpenRC services to find out the
+state of each one, to start and stop it, and any other functions related
+to it.
+.Pp
+Most functions should be self descriptive as to what they do and what they
+return based on names and arguments.
+.Pp
+.Fn rc_service_add
+adds the
+.Fa service
+to the
+.Fa runlevel .
+.Pp
+.Fn rc_service_delete
+deletes the
+.Fa service
+from the
+.Fa runlevel .
+.Pp
+.Fn rc_service_daemon_set
+saves the arguments in the
+.Fa service
+state data so that
+.Fn rc_service_daemons_crashed
+can check to see if they are still running or not.
+.Pp
+.Fn rc_service_description
+returns the
+.Va description
+variable of the
+.Fa service .
+If
+.Fa option
+is not null then we return the
+.Fa description_$option
+variable instead.
+.Pp
+.Fn rc_service_exists
+returns true if the
+.Fa service
+exists, otherwise false.
+.Pp
+.Fn rc_service_in_runlevel
+returns true if the
+.Fa service
+is in the
+.Fa runlevel ,
+otherwise false.
+.Pp
+.Fn rc_service_mark
+puts the
+.Fa service
+into the given
+.Fa state .
+If the state is RC_SERVICE_STOPPED then all data associated with the
+.Fa service
+is lost.
+.Fn rc_service_extra_commands
+returns a list of extra commands the
+.Fa service
+supports beyond the default ones. See
+.Nm openrc-run
+for default commands.
+.Pp
+.Fn rc_service_plugable
+returns true if the service is allowed to be plugged by
+.Pa rc.conf .
+Default is true.
+.Pp
+.Fn rc_service_resolve
+resolves
+.Fa service
+to the full path of service that was started, or would be started.
+.Pp
+When
+.Fa service
+starts, it starts
+.Fa service_to_start
+afterswards as directed by
+.Fn rc_service_schedule_start .
+.Fn rc_services_scheduled
+returns a list of services that will be started when
+.Fa service
+starts.
+.Fn rc_service_schedule_clear
+clears these scheduled services for
+.Fa service .
+.Pp
+.Fn rc_service_state returns the state of
+.Fa service .
+The return value is a bitmask, where more than one state can apply.
+.Pp
+.Fn rc_service_started_daemon
+checks to see if
+.Fa service
+started
+.Fa exec
+using
+.Nm start-stop-daemon .
+If
+.Fa indx
+is greater than zero, then it must also be the nth daemon started by
+.Fa service .
+.Fn rc_service_value_set
+saves the
+.Fa value
+under the name
+.Fa option .
+.Fn rc_service_value_get
+returns the value of the saved
+.Fa option .
+.Pp
+.Fn rc_services_in_runlevel
+returns a list of services in
+.Fa runlevel .
+If
+.Fa runlevel
+is not specified, then it returns a list of all available services.
+.Pp
+.Fn rc_services_in_state
+returns a list of all the services in
+.Fa state .
+.Sh IMPLEMENTATION NOTES
+Each function that returns
+.Fr "char *"
+returns a malloced NULL terminated string that should be freed when done.
+.Pp
+Each function that returns
+.Fr "RC_STRINGLIST *"
+should be freed using
+.Fn rc_stringlist_free
+when done.
+.Pp
+When a function fails it should either return false or NULL and set
+.Va errno
+unless specified otherwise as above.
+.Sh FILES
+.Pa /lib/rc/init.d
+normally holds the volatile state data for services on a RAM backed disk.
+.Sh SEE ALSO
+.Xr errno 3 ,
+.Xr malloc 3 ,
+.Xr free 3
+.Xr rc_stringlist_free 3 ,
+.Xr start-stop-daemon 8
+.Sh AUTHORS
+.An Roy Marples <roy@marples.name>

--- a/man3/rc_stringlist.3
+++ b/man3/rc_stringlist.3
@@ -1,0 +1,74 @@
+.\" Copyright (c) 2007-2015 The OpenRC Authors.
+.\" See the Authors file at the top-level directory of this distribution and
+.\" https://github.com/OpenRC/openrc/blob/master/AUTHORS
+.\"
+.\" This file is part of OpenRC. It is subject to the license terms in
+.\" the LICENSE file found in the top-level directory of this
+.\" distribution and at https://github.com/OpenRC/openrc/blob/master/LICENSE
+.\" This file may not be copied, modified, propagated, or distributed
+.\"    except according to the terms contained in the LICENSE file.
+.\"
+.Dd Mar 16, 2008
+.Dt RC_STRLIST 3 SMM
+.Os OpenRC
+.Sh NAME
+.Nm rc_stringlist_add , rc_stringlist_addu , rc_stringlist_delete ,
+.Nm rc_stringlist_free , rc_stringlist_new , rc_stringlist_sort
+.Nd RC string list functions
+.Sh LIBRARY
+Run Command library (librc, -lrc)
+.Sh SYNOPSIS
+.In rc.h
+.Ft "RC_STRINGLIST *" Fn rc_stringlist_new void
+.Ft "RC_STRING *" Fn rc_stringlist_add "RC_STRINGLIST *list" "const char *item"
+.Ft "RC_STRING *" Fn rc_stringlist_addu "RC_STRINGLIST *list" "const char *item"
+.Ft bool Fn rc_stringlist_delete RC_STRINGLIST "const char *item"
+.Ft void Fn rc_stringlist_free "RC_STRINGLIST *list"
+.Ft void Fn rc_stringlist_sort "RC_STRINGLIST *list"
+.Sh DESCRIPTION
+These functions provide an easy means of manipulating string lists. They are
+basically wrappers around TAILQ macros found in
+.Xr queue 3 .
+.Pp
+.Fn rc_stringlist_new
+creates a new list head to store the list.
+.Pp
+.Fn rc_stringlist_add
+adds a malloced copy of
+.Fa item
+to
+.Fa list .
+It returns a pointer to the new item on success, or NULL on failure and sets
+.Va errno
+accordingly.
+.Fn rc_stringlist_addu
+only works if
+.Fa list
+does not already contain
+.Fa item .
+.Pp
+.Fn rc_stringlist_delete
+removes and frees
+.Fa item
+from
+.Fa list ,
+retuning true on success, otherwise false.
+.Pp
+.Fn rc_stringlist_sort
+sorts the
+.Fa list
+according to C locale.
+.Pp
+.Fn rc_stringlist_free
+frees each item on
+.Fa list
+and the
+.Fa list
+itself.
+.Sh SEE ALSO
+.Xr malloc 3 ,
+.Xr free 3 ,
+.Xr queue 3 ,
+.Xr strcmp 3
+.Sh AUTHORS
+.An Roy Marples <roy@marples.name>

--- a/man8/openrc-init.8
+++ b/man8/openrc-init.8
@@ -1,0 +1,46 @@
+.\" Copyright (c) 2017 The OpenRC Authors.
+.\" See the Authors file at the top-level directory of this distribution and
+.\" https://github.com/OpenRC/openrc/blob/master/AUTHORS
+.\"
+.\" This file is part of OpenRC. It is subject to the license terms in
+.\" the LICENSE file found in the top-level directory of this
+.\" distribution and at https://github.com/OpenRC/openrc/blob/master/LICENSE
+.\" This file may not be copied, modified, propagated, or distributed
+.\"    except according to the terms contained in the LICENSE file.
+.\"
+.Dd April 6, 2017
+.Dt openrc-init 8 SMM
+.Os OpenRC
+.Sh NAME
+.Nm openrc-init
+.Nd the parent of all processes
+.Sh SYNOPSIS
+.Nm
+.Sh DESCRIPTION
+.Nm
+is an init process which can be an alternative to sysvinit or any other
+init process.
+.Pp
+To use
+.Nm
+configure your boot loader to invoke it or symlink it to /sbin/init.
+Also, you will need to use
+.Xr openrc-shutdown 8 ,
+to halt, reboot or poweroff the system.
+.Pp
+The default runlevel is read from the init command line, the
+rc_default_runlevel setting in rc.conf, the kernel command line, or it is
+assumed to be "default" if it is not set in any of these places.
+.Pp
+.Nm
+doesn't manage getty's directly, so you will need to manage them another
+way. For example, you can use the agetty service script as described in
+agetty-guide.md in this distribution.
+.Sh BUGS
+This was first released as part of OpenRC 0.25.
+I do not know of any specific issues. However, since this is the first
+release of openrc-init, please test and report any issues you find.
+.Sh SEE ALSO
+.Xr openrc-shutdown 8 ,
+.Sh AUTHORS
+.An William Hubbs <w.d.hubbs@gmail.com>

--- a/man8/openrc-run.8
+++ b/man8/openrc-run.8
@@ -1,0 +1,760 @@
+.\" Copyright (c) 2007-2015 The OpenRC Authors.
+.\" See the Authors file at the top-level directory of this distribution and
+.\" https://github.com/OpenRC/openrc/blob/master/AUTHORS
+.\"
+.\" This file is part of OpenRC. It is subject to the license terms in
+.\" the LICENSE file found in the top-level directory of this
+.\" distribution and at https://github.com/OpenRC/openrc/blob/master/LICENSE
+.\" This file may not be copied, modified, propagated, or distributed
+.\"    except according to the terms contained in the LICENSE file.
+.\"
+.Dd November 30, 2017
+.Dt openrc-run 8 SMM
+.Os OpenRC
+.Sh NAME
+.Nm openrc-run
+.Nd a means of hooking shell commands into a service
+.Sh SYNOPSIS
+.Nm
+.Op Fl D , -nodeps
+.Op Fl d , -debug
+.Op Fl s , -ifstarted
+.Op Fl S , -ifstopped
+.Op Fl Z , -dry-run
+.Op Ar command ...
+.Sh DESCRIPTION
+.Nm
+is basically an interpreter for shell scripts which provides an easy interface
+to the often complex system commands and daemons.
+When a service runs a command it first loads its multiplexed configuration
+file, then its master configuration file, then
+.Pa /etc/rc.conf
+and finally the script itself. At this point
+.Nm
+then runs the command given.
+.Pp
+Commands are defined as shell functions within the script. Here is a list of
+some functions that all scripts have by default:
+.Bl -tag -width "RC_DEFAULTLEVEL"
+.It Ar describe
+Describes what the service does and each command the service defines.
+.It Ar start
+First we ensure that any services we depend on are started. If any needed
+services fail to start then we exit with a suitable error, otherwise call the
+supplied start function if it exists.
+.It Ar stop
+First we ensure that any services that depend on us are stopped. If any
+services that need us fail to stop then we exit with a suitable error,
+otherwise call the supplied stop function if it exists.
+.It Ar restart
+Stops and starts the service, including dependencies. This cannot be
+overridden. See the description of the RC_CMD variable below for the
+method to make your service behave differently when restart is being
+executed.
+.It Ar status
+Shows the status of the service. The return code matches the status, with the
+exception of "started" returning 0 to match standard command behaviour.
+.It Ar zap
+Resets the service state to stopped and removes all saved data about the
+service.
+.El
+.Pp
+The following options affect how the service is run:
+.Bl -tag -width "RC_DEFAULTLEVEL"
+.It Fl d , -debug
+Set xtrace on in the shell to assist in debugging.
+.It Fl D , -nodeps
+Ignore all dependency information the service supplies.
+.It Fl s , -ifstarted
+Only run the command if the service has been started.
+.It Fl S , -ifstopped
+Only run the command if the service has been stopped.
+.It Fl q , -quiet
+Turns off all informational output the service generates.
+Output from any non OpenRC commands is not affected.
+.It Fl v , -verbose
+Turns on any extra informational output the service generates.
+.It Fl Z , -dry-run
+Shows which services would be stopped and/or started without actually stopping
+or starting them.
+.El
+.Pp
+The following variables affect the service script:
+.Bl -tag -width "RC_DEFAULTLEVEL"
+.It Ar extra_commands
+Space separated list of extra commands the service defines. These should
+not depend on the service being stopped or started.
+.It Ar extra_started_commands
+Space separated list of extra commands the service defines. These only work if
+the service has already been started.
+.It Ar extra_stopped_commands
+Space separated list of extra commands the service defines. These only work if
+the service has already been stopped.
+.It Ar description
+String describing the service.
+.It Ar description_$command
+String describing the extra command.
+.It Ar supervisor
+Supervisor to use to monitor this daemon. If this is unset or invalid,
+start-stop-daemon will be used.
+Currently, we support s6 from skarnet software, and supervise-daemon
+which is a light-weight supervisor internal to OpenRC.
+To use s6, set
+supervisor=s6.
+or set
+supervisor=supervise-daemon
+to use supervise-daemon.
+Note that supervise-daemon is still in early development, so it is
+considered experimental.
+.It Ar s6_service_path
+The path to the s6 service directory if you are monitoring this service
+with S6. The default is /var/svc.d/${RC_SVCNAME}.
+.It Ar s6_svwait_options_start
+The options to pass to s6-svwait when starting the service via s6.
+.It Ar s6_force_kill
+Should we force-kill this service if s6_service_timeout_stop expires
+but the service doesn't go down during shutdown? The default is yes.
+.It Ar s6_service_timeout_stop
+The amount of time, in milliseconds, s6-svc should wait for the service
+to go down when stopping the service. The default is 60000.
+.It Ar start_stop_daemon_args
+List of arguments passed to start-stop-daemon when starting the daemon.
+.It Ar supervise_daemon_args
+List of arguments passed to supervise-daemon when starting the daemon.
+If undefined, start_stop_daemon_args is used as a fallback.
+.It Ar command
+Daemon to start or stop via
+.Nm start-stop-daemon
+or
+.Nm supervise-daemon
+if no start or stop function is defined by the service.
+.It Ar command_args
+List of arguments to pass to the daemon when starting via
+.Nm start-stop-daemon .
+.It Ar command_args_background
+This variable should be used if the daemon you are starting with
+.Xr start-stop-daemon 8
+runs in the foreground by default but has its own command line options
+to request that it background and write a pid file. It should be set to
+those options. It should not be used at the same time as
+command_background, because command_background requests that
+.Xr start-stop-daemon 8
+go into the background before executing the daemon.
+.It Ar command_args_foreground
+List of arguments to pass to the daemon when starting via
+.Nm supervise-daemon .
+to force the daemon to stay in the foreground
+.It Ar command_background
+Set this to "true", "yes" or "1" (case-insensitive) if you want
+.Xr start-stop-daemon 8
+to force the daemon into the background. This forces the
+"--make-pidfile" and "--pidfile" options, so the pidfile variable must be set.
+.It Ar command_progress
+Set this to "true", "yes" or "1" (case-insensitive) if you want
+.Xr start-stop-daemon 8
+to display a progress meter when waiting for a daemon to stop.
+.It Ar command_user
+If the daemon does not support changing to a different user id, you can
+use this to change the user id, and optionally group id,  before
+.Xr start-stop-daemon 8
+or
+.Xr supervise-daemon 8
+launches the daemon.
+.It Ar output_log
+This is the path to a file or named pipe where the standard output from
+the service will be redirected. If you are starting this service with
+.Xr start-stop-daemon 8 ,
+,  you must set
+.Pa command_background
+to true. Keep in mind that this path will be inside the chroot if the
+.Pa chroot
+variable is set.
+.It Ar error_log
+The same thing as
+.Pa output_log
+but for the standard error output.
+.It Ar output_logger
+This is a process which will be used to log the standard output from the
+service.  If you are starting this service with
+.Xr start-stop-daemon 8 ,
+,  you must set
+.Pa command_background
+to true. Keep in mind that this command must be executable as a shell
+command inside the chroot if the
+.Pa chroot
+variable is set. Keep in mind also that this command works by accepting
+the stdout of the service on stdin.
+An example of a command that can be run this way is logger if you want
+your service output to go to syslog.
+.It Ar error_logger
+The same thing as
+.Pa output_logger
+but for the standard error output.
+.It Ar directory
+.Xr start-stop-daemon 8
+and
+.Xr supervise-daemon 8
+will chdir to this directory before starting the daemon.
+.It Ar chroot
+.Xr start-stop-daemon 8
+and
+.Xr supervise-daemon 8
+will chroot into this path before writing the pid file or starting the daemon.
+.It Ar pidfile
+Pidfile to use for the above defined command.
+.It Ar name
+Display name used for the above defined command.
+.It Ar procname
+Process name to match when signaling the daemon.
+.It Ar stopsig
+Signal to send when stopping the daemon.
+.It Ar respawn_delay
+Respawn delay
+.Xr supervise-daemon 8
+will use for this daemon.  See
+.Xr supervise-daemon 8
+for more information about this setting.
+.It Ar respawn_max
+Respawn max
+.Xr supervise-daemon 8
+will use for this daemon.  See
+.Xr supervise-daemon 8
+for more information about this setting.
+.It Ar respawn_period
+Respawn period
+.Xr supervise-daemon 8
+will use for this daemon.  See
+.Xr supervise-daemon 8
+for more information about this setting.
+.It Ar retry
+Retry schedule to use when stopping the daemon. It can either be a
+timeout in seconds or multiple signal/timeout pairs (like SIGTERM/5).
+.It Ar required_dirs
+A list of directories which must exist for the service to start.
+.It Ar required_files
+A list of files which must exist for the service to start.
+.It Ar start_inactive
+Set to yes to have the service marked inactive when it starts. This is
+used along with in_background_fake to support re-entrant services.
+.It Ar in_background_fake
+Space separated list of commands which should always succeed when
+in_background is yes.
+.It Ar umask
+Set the umask of the daemon.
+.Pp
+Keep in mind that eval is used to process chroot, command, command_args_*,
+command_user, pidfile and procname. This may affect how they are
+evaluated depending on how they are quoted.
+.El
+.Sh DEPENDENCIES
+You should define a
+.Ic depend
+function for the service so that
+.Nm
+will start and stop it in the right order in relation to other services.
+As it's a function it can be very flexible, see the example below.
+Here is a list of the functions you can use in a
+.Ic depend
+function. You simply pass the names of the services you want to add to
+that dependency type to the function, or prefix the names with ! to
+remove them from the dependencies.
+.Bl -tag -width "RC_DEFAULTLEVEL"
+.It Ic need
+The service will attempt to start any services it needs regardless of
+whether they have been added to the runlevel. It will refuse to start
+until all services it needs have started, and it will refuse to stop until all
+services that need it have stopped.
+.It Ic use
+The service will attempt to start any services it uses that have been added
+to the runlevel.
+.It Ic want
+The service will attempt to start any services it wants, regardless of
+whether they have been added to the runlevel.
+.It Ic after
+The service will start after these services and stop before these services.
+.It Ic before
+The service will start before these services and stop after these services.
+.It Ic provide
+The service provides this virtual service. For example, named provides dns.
+Note that it is not legal to have a virtual and real service with the
+same name. If you do this, you will receive an error message, and you
+must rename either the real or virtual service.
+.It Ic config
+We should recalculate our dependencies if the listed files have changed.
+.It Ic keyword
+Tags a service with a keyword. These are the keywords we currently understand:
+.Bl -tag -width indent
+.It Dv -shutdown
+Don't stop this service when shutting the system down.
+This is normally quite safe as remaining daemons will be sent a SIGTERM just
+before final shutdown.
+Network related services such as the network and dhcpcd init scripts normally
+have this keyword.
+.It Dv -stop
+Don't stop this service when changing runlevels, even if not present.
+This includes shutting the system down.
+.It Dv -timeout
+Other services should wait indefinitely for this service to start. Use
+this keyword if your service may take longer than 60 seconds to start.
+.It Dv -jail
+When in a jail, exclude this service from any dependencies. The service can
+still be run directly. Set via
+.Ic rc_sys
+in
+.Pa /etc/rc.conf
+.It Dv -lxc
+Same as -jail, but for Linux Resource Containers (LXC).
+.It Dv -openvz
+Same as -jail, but for OpenVZ systems.
+.It Dv -prefix
+Same as -jail, but for Prefix systems.
+.It Dv -rkt
+Same as -jail, but for RKT systems.
+.It Dv -uml
+Same as -jail, but for UML systems.
+.It Dv -vserver
+Same as -jail, but for VServer systems.
+.It Dv -xen0
+Same as -jail, but for Xen DOM0 systems.
+.It Dv -xenu
+Same as -jail, but for Xen DOMU systems.
+.It Dv -docker
+Same as -jail, but for docker systems.
+.It Dv -containers
+Same as -jail, but for all relevant container types on the operating
+system.
+.El
+.El
+.Pp
+To see how to influence dependencies in configuration files, see the
+.Sx FILES
+section below.
+.Sh _pre AND _post FUNCTIONS
+Any command defined in extra_commands, extra_started_commands or
+extra_stopped_commands can have _pre and _post functions in the service
+script. If the command function is called foo, the_pre and _post
+functions for it should be called foo_pre and foo_post.
+.Pp
+These functions should be used to perform preparation before the
+command is run and cleanup after the command completes. In order for
+.Nm
+to record the command as being run successfully, the _pre
+function, command function itself and the _post function should all exit
+with a zero return code.
+.Sh BUILTINS
+.Nm
+defines some builtin functions that you can use inside your service scripts:
+.Bl -tag -width indent
+.It Ic einfo Op Ar string
+Output a green asterisk followed by the string.
+.It Ic ewarn Op Ar string
+Output a yellow asterisk followed by the string.
+.It Ic eerror Op Ar string
+Output a red asterisk followed by the string to stderr.
+.It Ic ebegin Op Ar string
+Same as einfo, but append 3 dots to the end.
+.It Ic eend Ar retval Op Ar string
+If
+.Ar retval
+does not equal 0 then output the string using
+.Ic eerror
+and !! in square brackets
+at the end of the line.
+Otherwise output ok in square brackets at the end of the line.
+The value of
+.Ar retval
+is returned.
+.It Ic ewend Ar retval Op Ar string
+Same as
+.Ic eend ,
+but use
+.Ic ewarn
+instead of
+.Ic eerror .
+.El
+.Pp
+You can prefix the above commands with the letter
+.Ic v ,
+which means they only
+output when the environment variable
+.Va EINFO_VERBOSE
+is true.
+.Bl -tag -width indent
+.It Ic ewaitfile Ar timeout Ar file1 Ar file2 ...
+Wait for
+.Ar timeout
+seconds until all files exist.
+Returns 0 if all files exist, otherwise non zero.
+If
+.Ar timeout
+is less than 1 then we wait indefinitely.
+.It Ic is_newer_than Ar file1 Ar file2 ...
+If
+.Ar file1
+is newer than
+.Ar file2
+return 0, otherwise 1.
+If
+.Ar file2
+is a directory, then check all its contents too.
+.It Ic is_older_than Ar file1 Ar file2 ...
+If
+.Ar file1
+is newer than
+.Ar file2
+return 0, otherwise 1.
+If
+.Ar file2
+is a directory, then check all its contents too.
+.It Ic service_set_value Ar name Ar value
+Saves the
+.Ar name
+.Ar value
+for later retrieval. Saved values are lost when the service stops.
+.It Ic service_get_value Ar name
+Returns the saved value called
+.Ar name .
+.It Ic service_started Op Ar service
+If the service is started, return 0 otherwise 1.
+.It Ic service_starting Op Ar service
+If the service is starting, return 0 otherwise 1.
+.It Ic service_inactive Op Ar service
+If the service is inactive, return 0 otherwise 1.
+.It Ic service_stopping Op Ar service
+If the service is stopping, return 0 otherwise 1.
+.It Ic service_stopped Op Ar service
+If the service is stopped, return 0 otherwise 1.
+.It Ic service_coldplugged Op Ar service
+If the service is coldplugged, return 0 otherwise 1.
+.It Ic service_wasinactive Op Ar service
+If the service was inactive, return 0 otherwise 1.
+.It Xo
+.Ic service_started_daemon
+.Op Ar service
+.Ar daemon
+.Op Ar index
+.Xc
+If the service has started the daemon using
+.Nm start-stop-daemon ,
+return 0 otherwise 1.
+If an index is specified, it has to be the nth daemon started by the service.
+.It Ic mark_service_started Op Ar service
+Mark the service as started.
+.It Ic mark_service_starting Op Ar service
+Mark the service as starting.
+.It Ic mark_service_inactive Op Ar service
+Mark the service as inactive.
+.It Ic mark_service_stopping Op Ar service
+Mark the service as stopping.
+.It Ic mark_service_stopped Op Ar service
+Mark the service as stopped.
+.It Ic mark_service_coldplugged Op Ar service
+Mark the service as coldplugged.
+.It Ic mark_service_wasinactive Op Ar service
+Mark the service as inactive.
+.It Xo
+.Ic checkpath
+.Op Fl D , -directory-truncate
+.Op Fl d , -directory
+.Op Fl F , -file-truncate
+.Op Fl f , -file
+.Op Fl p , -pipe
+.Op Fl m , -mode Ar mode
+.Op Fl o , -owner Ar owner
+.Op Fl W , -writable
+.Op Fl q , -quiet
+.Ar path ...
+.Xc
+If -d, -f or -p is specified, checkpath checks to see if the path
+exists, is the right type and has the correct owner and access modes. If
+any of these tests fail, the path is created and set up as specified. If
+more than one of -d, -f or -p are specified, the last one will be used.
+.Pp
+The argument to -m is a three or four digit octal number. If this option
+is not provided, the value defaults to 0644 for files and 0775 for
+directories.
+.Pp
+The argument to -o is a representation of the user and/or group which
+should own the path. The user and group can be represented numerically
+or with names, and are separated by a colon.
+.Pp
+The truncate options (-D and -F) cause the directory or file to be
+cleared of all contents.
+.Pp
+If -W is specified, checkpath checks to see if the first path given on
+the command line is writable.  This is different from how the test
+command in the shell works, because it also checks to make sure the file
+system is not read only.
+.Pp
+Also, the -d, -f or -p options should not be specified along with this option.
+.Pp
+The -q option suppresses all informational output. If it is specified
+twice, all error messages are suppressed as well.
+.It Xo
+.Ic fstabinfo
+.Op Fl M , -mount
+.Op Fl R , -remount
+.Op Fl b , -blockdevice
+.Op Fl m , -mountargs
+.Op Fl o , -options
+.Op Fl p , -passno Ar passno
+.Op Fl t , -type Ar fstype
+.Ar path
+.Xc
+If -b, -m, -o, -p or -t is specified,the appropriate information is
+extracted from fstab. If -M or -R are given, file systems are mounted or
+remounted.
+.Pp
+The -q option suppresses all informational output. If it is specified
+twice, all error messages are suppressed as well.
+.It Xo
+.Ic mountinfo
+.Op Fl f, -fstype-regex Ar regex
+.Op Fl F, -skip-fstype-regex Ar regex
+.Op Fl n, -node-regex Ar regex
+.Op Fl N, -skip-node-regex Ar regex
+.Op Fl o, -options-regex Ar regex
+.Op Fl O, -skip-options-regex Ar regex
+.Op Fl p, -point-regex Ar regex
+.Op Fl P, -skip-point-regex Ar regex
+.Op Fl e, -netdev
+.Op Fl E, -nonetdev
+.Op Fl i, -options
+.Op Fl s, -fstype
+.Op Fl t, -node
+.Ar mount1 mount2 ...
+.Xc
+The f, F, n, N, o, O, p, P, e and E options specify what you want to
+search for or skip in the mounted file systems. The i, s and t options
+specify what you want to display. If no mount points are given, all
+mount points will be considered.
+.It Ic yesno Ar value
+If
+.Ar value
+matches YES, TRUE, ON or 1 regardless of case then we return 0, otherwise 1.
+.El
+.Sh ENVIRONMENT
+.Nm
+sets the following environment variables for use in the service scripts:
+.Bl -tag -width "RC_DEFAULTLEVEL"
+.It Va RC_SVCNAME
+Name of the service.
+.It Va RC_SERVICE
+Full path to the service.
+.It Va RC_RUNLEVEL
+Current runlevel that OpenRC is in. Note that, in OpenRC, the reboot
+runlevel is mapped to the shutdown runlevel. This was done because most
+services do not need to know if a system is shutting down or rebooting.
+If you are writing a service that does need to know this, see the
+RC_REBOOT variable.
+.It Va RC_REBOOT
+This variable contains YES if the system is rebooting. If your service
+needs to know the system is rebooting, you should test this variable.
+.It Va RC_BOOTLEVEL
+Boot runlevel chosen. Default is boot.
+.It Va RC_DEFAULTLEVEL
+Default runlevel chosen. Default is default.
+.It Va RC_SYS
+A special variable to describe the system more.
+Possible values are OPENVZ, XENU, XEN0, UML and VSERVER.
+.It Va RC_PREFIX
+In a Gentoo Prefix installation, this variable contains the prefix
+offset. Otherwise it is undefined.
+.It Va RC_UNAME
+The result of `uname -s`.
+.It Va RC_CMD
+This contains the name of the command the service script is executing, such
+as start, stop, restart etc. One example of using this is to make a
+service script behave differently when restart is being executed.
+.It Va RC_GOINGDOWN
+This variable contains YES if the system is going into single user mode
+or shutting down.
+.It Va RC_LIBEXECDIR
+The value of libexecdir which OpenRC was configured with during build
+time.
+.It Va RC_NO_UMOUNTS
+This variable is used by plugins to contain a list of directories which
+should not be unmounted.
+.El
+.Sh FILES
+.Pp
+Configuration files, relative to the location of the service.
+If a file ending with .${RC_RUNLEVEL} exists then we use that instead.
+.Bl -ohang
+.It Pa ../conf.d/${RC_SVCNAME%%.*}
+multiplexed configuration file.
+Example: if ${RC_SVCNAME} is net.eth1 then look for
+.Pa ../conf.d/net .
+.It Pa ../conf.d/${RC_SVCNAME}
+service configuration file.
+.It Pa /etc/rc.conf
+host configuration file.
+.El
+.Pp
+With the exception of
+.Pa /etc/rc.conf ,
+the configuration files can also influence the dependencies of the service
+through variables. Simply prefix the name of the dependency with rc_.
+Examples:
+.Bd -literal -offset indent
+# Whilst most services don't bind to a specific interface, our
+# openvpn configuration requires a specific interface, namely bge0.
+rc_need="net.bge0"
+# To put it in /etc/rc.conf you would do it like this
+rc_openvpn_need="net.bge0"
+
+# Services should not depend on the tap1 interface for network,
+# but we need to add net.tap1 to the default runlevel to start it.
+rc_provide="!net"
+# To put it in /etc/conf.d/net you would do it like this
+rc_provide_tap1="!net"
+# To put in in /etc/rc.conf you would do it like this
+rc_net_tap1_provide="!net"
+
+# It's also possible to negate keywords. This is mainly useful for prefix
+# users testing OpenRC.
+rc_keyword="!-prefix"
+# This can also be used to block a script from running in all
+# containers except one or two
+rc_keyword="!-containers !-docker"
+.Ed
+.Sh EXAMPLES
+.Pp
+An example service script for foo.
+.Bd -literal -offset indent
+#!/sbin/openrc-run
+command=/usr/bin/foo
+command_args="${foo_args} --bar"
+pidfile=/var/run/foo.pid
+name="FooBar Daemon"
+
+description="FooBar is a daemon that eats and drinks"
+extra_commands="show"
+extra_started_commands="drink eat"
+description_drink="Opens mouth and reflexively swallows"
+description_eat="Chews food in mouth"
+description_show="Shows what's in the tummy"
+
+_need_dbus()
+{
+    grep -q dbus /etc/foo/plugins
+}
+
+depend()
+{
+    # We write a pidfile and to /var/cache, so we need localmount.
+    need localmount
+    # We can optionally use the network, but it's not essential.
+    use net
+    # We should be after bootmisc so that /var/run is cleaned before
+    # we put our pidfile there.
+    after bootmisc
+
+    # Foo may use a dbus plugin.
+    # However, if we add the dbus plugin whilst foo is running and
+    # stop dbus, we don't need to stop foo as foo didn't use dbus.
+    config /etc/foo/plugins
+    local _need=
+    if service_started; then
+	_need=`service_get_value need`
+    else
+	if _need_dbus; then
+	   _need="${_need} dbus"
+	fi
+    fi
+    need ${_need}
+}
+
+# This function does any pre-start setup. If it fails, the service will
+# not be started.
+# If you need this function to behave differently for a restart command,
+# you should check the value of RC_CMD for "restart".
+# This also applies to start_post, stop_pre and stop_post.
+start_pre()
+{
+	if [ "$RC_CMD" = restart ]; then
+		# This block will only execute for a restart command. Use a
+		# structure like this if you need special processing for a
+		# restart which you do not need for a normal start.
+		# The function can also fail from here, which will mean that a
+		# restart can fail.
+		# This logic can also be used in start_post, stop_pre and
+		# stop_post.
+	fi
+    # Ensure that our dirs are correct
+    checkpath --directory --owner foo:foo --mode 0775 \\
+	/var/run/foo /var/cache/foo
+}
+
+start_post()
+{
+    # Save our need
+    if _need_dbus; then
+	service_set_value need dbus
+    fi
+}
+
+stop_post() {
+    # Clean any spills
+    rm -rf /var/cache/foo/*
+}
+
+drink()
+{
+    ebegin "Starting to drink"
+    ${command} --drink beer
+    eend $? "Failed to drink any beer :("
+}
+
+eat()
+{
+    local result=0 retval= ate= food=
+    ebegin "Starting to eat"
+
+    if yesno "${foo_diet}"; then
+    	eend 1 "We are on a diet!"
+	return 1
+    fi
+
+    for food in /usr/share/food/*; do
+	veinfo "Eating `basename ${food}`"
+	${command} --eat ${food}
+	retval=$?
+	: $(( result += retval ))
+	[ ${retval} = 0 ] && ate="${ate} `basename ${food}`"
+    done
+
+    if eend ${result} "Failed to eat all the food"; then
+	service_set_value ate "${ate}"
+    fi
+}
+
+show()
+{
+    einfo "Foo has eaten: `service_get_value ate`"
+}
+
+.Ed
+.Sh BUGS
+Because of the way we load our configuration files and the need to handle
+more than one service directory, you can only use symlinks in service
+directories to other services in the same directory.
+You cannot symlink to a service in a different directory even if it is
+another service directory.
+.Pp
+is_older_than should return 0 on success.
+Instead we return 1 to be compliant with Gentoo baselayout.
+Users are encouraged to use the is_newer_than function which returns correctly.
+.Sh SEE ALSO
+.Xr einfo 3 ,
+.Xr openrc 8 ,
+.Xr rc-status 8 ,
+.Xr rc-update 8 ,
+.Xr rc_plugin_hook 3 ,
+.Xr sh 1p ,
+.Xr start-stop-daemon 8 ,
+.Xr supervise-daemon 8 ,
+.Xr uname 1
+.Sh AUTHORS
+.An Roy Marples <roy@marples.name>
+.An William Hubbs <w.d.hubbs@gmail.com>

--- a/man8/openrc-shutdown.8
+++ b/man8/openrc-shutdown.8
@@ -1,0 +1,65 @@
+.\" Copyright (c) 2017 The OpenRC Authors.
+.\" See the Authors file at the top-level directory of this distribution and
+.\" https://github.com/OpenRC/openrc/blob/master/AUTHORS
+.\"
+.\" This file is part of OpenRC. It is subject to the license terms in
+.\" the LICENSE file found in the top-level directory of this
+.\" distribution and at https://github.com/OpenRC/openrc/blob/master/LICENSE
+.\" This file may not be copied, modified, propagated, or distributed
+.\"    except according to the terms contained in the LICENSE file.
+.\"
+.Dd May 22, 2017
+.Dt openrc-shutdown 8 SMM
+.Os OpenRC
+.Sh NAME
+.Nm openrc-shutdown
+.Nd bring the system down
+.Sh SYNOPSIS
+.Nm
+.Op Fl c , -cancel
+.Op Fl d , -no-write
+.Op Fl D , -dry-run
+.Op Fl H , -halt
+.Op Fl k , -kexec
+.Op Fl p , -poweroff
+.Op Fl R , -reexec
+.Op Fl r , -reboot
+.Op Fl s , -single
+.Op Fl w , -write-only
+.Sh DESCRIPTION
+.Nm
+is the utility that communicates with
+.Xr openrc-init 8
+to bring down the system or instruct openrc-init to re-execute itself.
+It supports the following options:
+.Bl -tag -width "poweroff"
+.It Fl c , -cancel
+Cancel a pending shutdown.
+.It Fl d , -no-write
+Do not write the wtmp boot record.
+.It Fl D , -dry-run
+Print the action that would be taken without executing it. This is to
+allow testing.
+.It Fl H , -halt
+Stop all services, kill all remaining processes and halt the system.
+.It Fl k , -kexec
+Stop all services, kill all processes and boot directly into a new
+kernel loaded via
+.Xr kexec 8 .
+.It Fl p , -poweroff
+Stop all services, kill all processes and power off the system.
+.It Fl R , -reexec
+instruct openrc-init to re-exec itself. This should be used after an
+upgrade of OpenRC if you are using openrc-init as your init process.
+.It Fl r , -reboot
+Stop all services, kill all processes and reboot the system.
+.It Fl s , -single
+Stop all services, kill all processes and move to single user mode.
+.It Fl w , -write-only
+Stop all services, kill all processes and move to single user mode.
+.El
+.Sh SEE ALSO
+.Xr openrc-init 8 ,
+.Xr kexec 8 ,
+.Sh AUTHORS
+.An William Hubbs <w.d.hubbs@gmail.com>

--- a/man8/openrc.8
+++ b/man8/openrc.8
@@ -1,0 +1,74 @@
+.\" Copyright (c) 2007-2015 The OpenRC Authors.
+.\" See the Authors file at the top-level directory of this distribution and
+.\" https://github.com/OpenRC/openrc/blob/master/AUTHORS
+.\"
+.\" This file is part of OpenRC. It is subject to the license terms in
+.\" the LICENSE file found in the top-level directory of this
+.\" distribution and at https://github.com/OpenRC/openrc/blob/master/LICENSE
+.\" This file may not be copied, modified, propagated, or distributed
+.\"    except according to the terms contained in the LICENSE file.
+.\"
+.Dd May 2, 2009
+.Dt OPENRC 8 SMM
+.Os OpenRC
+.Sh NAME
+.Nm openrc
+.Nd stops and starts services for the specified runlevel
+.Sh SYNOPSIS
+.Nm
+.Op Fl n , -no-stop
+.Op Fl o , -override
+.Op Ar runlevel
+.Sh DESCRIPTION
+.Nm
+first stops any services that are not in the specified runlevel unless
+--no-stop is specified, then starts any services in the runlevel and
+stacked runlevels added by
+.Nm rc-update
+that are not currently started.
+If no runlevel is specified, we use the current runlevel.
+.Pp
+There are some special runlevels that you should be aware of:
+.Bl -tag -width "shutdown"
+.It Ar sysinit
+Brings up any system specific stuff such as
+.Pa /dev ,
+.Pa /proc
+and optionally
+.Pa /sys
+for Linux based systems. It also mounts
+.Pa /lib/rc/init.d
+as a ramdisk using tmpfs where available unless / is mounted rw at boot.
+.Nm
+uses
+.Pa /lib/rc/init.d
+to hold state information about the services it runs.
+sysinit always runs when the host first starts should not be run again.
+.It Ar boot
+Generally the only services you should add to the boot runlevel are those
+which deal with the mounting of filesystems, set the initial state of attached
+peripherals and logging.
+Hotplugged services are added to the boot runlevel by the system.
+All services in the boot and sysinit runlevels are automatically included
+in all other runlevels except for those listed here.
+.It Ar single
+Stops all services except for those in the sysinit runlevel.
+.It Ar reboot
+Changes to the shutdown runlevel and then reboots the host.
+.It Ar shutdown
+Changes to the shutdown runlevel and then halts the host.
+.El
+.Pp
+You should not call any of these runlevels yourself.
+Instead you should use
+.Xr init 8
+and
+.Xr shutdown 8
+and let them call these special runlevels.
+.Sh SEE ALSO
+.Xr rc-status 8 ,
+.Xr rc-update 8 ,
+.Xr init 8 ,
+.Xr shutdown 8
+.Sh AUTHORS
+.An Roy Marples Aq roy@marples.name

--- a/man8/rc-service.8
+++ b/man8/rc-service.8
@@ -1,0 +1,104 @@
+.\" Copyright (c) 2007-2015 The OpenRC Authors.
+.\" See the Authors file at the top-level directory of this distribution and
+.\" https://github.com/OpenRC/openrc/blob/master/AUTHORS
+.\"
+.\" This file is part of OpenRC. It is subject to the license terms in
+.\" the LICENSE file found in the top-level directory of this
+.\" distribution and at https://github.com/OpenRC/openrc/blob/master/LICENSE
+.\" This file may not be copied, modified, propagated, or distributed
+.\"    except according to the terms contained in the LICENSE file.
+.\"
+.Dd May 1, 2009
+.Dt RC-SERVICE 8 SMM
+.Os OpenRC
+.Sh NAME
+.Nm rc-service
+.Nd locate and run an OpenRC service with the given arguments
+.Sh SYNOPSIS
+.Nm
+.Op Fl c , -ifcrashed
+.Ar service cmd
+.Op Ar ...
+.Nm
+.Fl d , -debug
+.Ar service cmd
+.Op Ar ...
+.Nm
+.Fl D , -nodeps
+.Ar service cmd
+.Op Ar ...
+.Nm
+.Op Fl i , -ifexists
+.Ar service cmd
+.Op Ar ...
+.Nm
+.Op Fl I , -ifinactive
+.Ar service cmd
+.Op Ar ...
+.Nm
+.Op Fl N , -ifnotstarted
+.Ar service cmd
+.Op Ar ...
+.Nm
+.Op Fl s , -ifstarted
+.Ar service cmd
+.Op Ar ...
+.Nm
+.Op Fl S , -ifstopped
+.Ar service cmd
+.Op Ar ...
+.Nm
+.Fl e , -exists
+.Ar service
+.Nm
+.Fl Z , -dry-run
+.Ar service cmd
+.Op Ar ...
+.Nm
+.Fl l , -list
+.Nm
+.Fl r , -resolve
+.Ar service
+.Sh DESCRIPTION
+Service scripts could be in different places on different systems.
+.Nm
+locates the specified service and runs it with the given arguments.
+If
+.Fl i , -ifexists
+is given then
+.Nm
+returns 0 even if the service does not exist.
+If
+.Fl I , -ifinactive
+or
+.Fl N , -ifnotstarted
+is given then
+.Nm
+returns 0 if the service exists but is in the wrong state.
+.Pp
+If given the
+.Fl l , -list
+argument then
+.Nm
+will list all available services.
+.Pp
+.Fl e , -exists
+return 0 if it can find
+.Ar service ,
+otherwise -1.
+.Fl r , -resolve
+does the same and also prints the full path of the service to stdout.
+.Pp
+.Fl d , -debug
+sets -x when running the service script(s).
+.Pp
+.Fl D , -nodeps
+ignores dependencies when running the service.
+.Pp
+.Fl Z , -dry-run
+displays commands rather than executing them.
+.Sh SEE ALSO
+.Xr openrc 8 ,
+.Xr stdout 3
+.Sh AUTHORS
+.An Roy Marples <roy@marples.name>

--- a/man8/rc-sstat.8
+++ b/man8/rc-sstat.8
@@ -1,0 +1,33 @@
+.\" Copyright (c) 2015 The OpenRC Authors.
+.\" See the Authors file at the top-level directory of this distribution and
+.\" https://github.com/OpenRC/openrc/blob/master/AUTHORS
+.\"
+.\" This file is part of OpenRC. It is subject to the license terms in
+.\" the LICENSE file found in the top-level directory of this
+.\" distribution and at https://github.com/OpenRC/openrc/blob/master/LICENSE
+.\" This file may not be copied, modified, propagated, or distributed
+.\"    except according to the terms contained in the LICENSE file.
+.\"
+.Dd April 24, 2008
+.Dt RC-sstat 8 SMM
+.Os OpenRC
+.Sh NAME
+.Nm rc-sstat
+.Nd show status info about services supervised by s6 then rc-status
+info
+.Sh SYNOPSIS
+.Nm
+.Sh DESCRIPTION
+.Nm
+gathers and displays information about the status of services supervised
+by s6 then runs rc-status to show info about nnormal OpenRC services.
+.Pp
+.Sh EXIT STATUS
+.Nm
+exits 1 if there is an internal error or exits with the same exit codes
+as rc-status.
+.Sh SEE ALSO
+.Xr rc-status 8 ,
+.Xr rc-update 8
+.Sh AUTHORS
+.An William Hubbs <w.d.hubbs@gmail.com>

--- a/man8/rc-status.8
+++ b/man8/rc-status.8
@@ -1,0 +1,68 @@
+.\" Copyright (c) 2007-2015 The OpenRC Authors.
+.\" See the Authors file at the top-level directory of this distribution and
+.\" https://github.com/OpenRC/openrc/blob/master/AUTHORS
+.\"
+.\" This file is part of OpenRC. It is subject to the license terms in
+.\" the LICENSE file found in the top-level directory of this
+.\" distribution and at https://github.com/OpenRC/openrc/blob/master/LICENSE
+.\" This file may not be copied, modified, propagated, or distributed
+.\"    except according to the terms contained in the LICENSE file.
+.\"
+.Dd April 24, 2008
+.Dt RC-STATUS 8 SMM
+.Os OpenRC
+.Sh NAME
+.Nm rc-status
+.Nd show status info about runlevels
+.Sh SYNOPSIS
+.Nm
+.Op Fl aclsuC
+.Op Ar runlevel
+.Sh DESCRIPTION
+.Nm
+gathers and displays information about the status of services
+in different runlevels.  The default behavior is to show information
+about the current runlevel and any unassigned services that are not stopped,
+but any runlevel can be quickly examined.
+.Pp
+If an active service is being supervised by
+.Xr supervise-daemon 8, 
+the amount of time the daemon has been active along with the number of
+times it has been respawned in the current respawn period will be
+displayed.
+.Pp
+The options are as follows:
+.Bl -tag -width ".Fl test , test string"
+.It Fl a , -all
+Show all runlevels and their services.
+.It Fl c , -crashed
+List all services that have crashed.
+.It Fl l , -list
+List all defined runlevels.
+.It Fl m , -manual
+Show all manually started services.
+.It Fl r , -runlevel
+Print the current runlevel name.
+.It Fl s , -servicelist
+Show all services.
+.It Fl u , -unused
+Show services not assigned to any runlevel.
+.It Fl C , -nocolor
+Disable color output.
+.It Ar runlevel
+Show information only for the named
+.Ar runlevel .
+.El
+.Sh EXIT STATUS
+.Nm
+exits 0, except when checking for crashed services and it doesn't find any.
+.Sh IMPLEMENTATION NOTES
+.Nm
+tries to list services within each runlevel in the presently resolved
+dependency order if the dependency tree is available.
+.Sh SEE ALSO
+.Xr openrc 8 ,
+.Xr rc-update 8
+.Xr supervise-daemon 8
+.Sh AUTHORS
+.An Roy Marples <roy@marples.name>

--- a/man8/rc-update.8
+++ b/man8/rc-update.8
@@ -1,0 +1,89 @@
+.\" Copyright (c) 2007-2015 The OpenRC Authors.
+.\" See the Authors file at the top-level directory of this distribution and
+.\" https://github.com/OpenRC/openrc/blob/master/AUTHORS
+.\"
+.\" This file is part of OpenRC. It is subject to the license terms in
+.\" the LICENSE file found in the top-level directory of this
+.\" distribution and at https://github.com/OpenRC/openrc/blob/master/LICENSE
+.\" This file may not be copied, modified, propagated, or distributed
+.\"    except according to the terms contained in the LICENSE file.
+.\"
+.Dd Jan 13, 2014
+.Dt RC-UPDATE 8 SMM
+.Os OpenRC
+.Sh NAME
+.Nm rc-update
+.Nd add and remove services to and from a runlevel
+.Sh SYNOPSIS
+.Nm
+.Op Fl s , -stack
+.Ar add
+.Ar service
+.Op Ar runlevel ...
+.Nm
+.Op Fl s , -stack
+.Op Fl a , -all
+.Ar delete
+.Ar service
+.Op Ar runlevel ...
+.Nm
+.Op Fl u , -update
+.Op Fl v , -verbose
+.Ar show
+.Op Ar runlevel ...
+.Sh DESCRIPTION
+OpenRC uses named runlevels.  Rather than editing some obscure
+file or managing a directory of symlinks,
+.Nm
+exists to quickly add or delete services to and from from different runlevels.
+All services must reside in the
+.Pa /etc/init.d
+or
+.Pa /usr/local/etc/init.d
+directories.
+They must also be standard OpenRC scripts, meaning they must use
+openrc-run.
+.Pp
+.Bl -tag -width "Fl a , -delete service"
+.It Ar add Ar service
+Add the
+.Ar service
+to the
+.Ar runlevel
+or the current one if none given.
+Services added to the boot runlevel must exist in
+.Pa /etc/init.d .
+.It Ar delete Ar service
+Delete the
+.Ar service
+from the
+.Ar runlevel
+or the current one if none given.
+.It Ar show
+Show all enabled services and the runlevels they belong to.  If you specify
+runlevels to show, then only those will be included in the output.
+.It Fl v , -verbose
+Show all services.
+.It Fl u , -update
+Forces an update of the dependency tree cache.
+This may be needed in the event of clock skew (a file in /etc is newer than the
+system clock).
+.El
+.Pp
+If the
+.Fl s , -stack
+option is given then we either add or remove the runlevel from the runlevel.
+This allows inheritance of runlevels.
+.Pp
+If the
+.Fl a, -all
+option is given, we remove the service from all runlevels. This is
+useful, for example, to clean up the dangling symlinks after a service
+is removed.
+.Sh SEE ALSO
+.Xr openrc 8 ,
+.Xr openrc-run 8 ,
+.Xr rc-status 8
+.Sh AUTHORS
+.An Roy Marples <roy@marples.name>
+.An The OpenRC Team <openrc@gentoo.org>

--- a/man8/start-stop-daemon.8
+++ b/man8/start-stop-daemon.8
@@ -1,0 +1,220 @@
+.\" Copyright (c) 2007-2015 The OpenRC Authors.
+.\" See the Authors file at the top-level directory of this distribution and
+.\" https://github.com/OpenRC/openrc/blob/master/AUTHORS
+.\"
+.\" This file is part of OpenRC. It is subject to the license terms in
+.\" the LICENSE file found in the top-level directory of this
+.\" distribution and at https://github.com/OpenRC/openrc/blob/master/LICENSE
+.\" This file may not be copied, modified, propagated, or distributed
+.\"    except according to the terms contained in the LICENSE file.
+.\"
+.Dd December 14, 2009
+.Dt START-STOP-DAEMON 8 SMM
+.Os OpenRC
+.Sh NAME
+.Nm start-stop-daemon
+.Nd ensures that daemons start and stop
+.Sh SYNOPSIS
+.Nm
+.Fl S , -start
+.Ar daemon
+.Op Fl -
+.Op Ar arguments
+.Nm
+.Fl K , -stop
+.Ar daemon
+.Nm
+.Fl s , -signal
+.Ar signal
+.Ar daemon
+.Sh DESCRIPTION
+.Nm
+provides a consistent method of starting, stopping and signaling daemons.
+If neither
+.Fl K , -stop
+nor
+.Fl s , -signal
+are provided, then we assume we are starting the daemon.
+If a daemon cannot background by itself, nor create a pidfile,
+.Nm
+can do it for the daemon in a secure fashion.
+.Pp
+If
+.Nm
+is used in an OpenRC service, then OpenRC can in turn check to see if the
+daemon is still running. If not, then the service is marked as crashed.
+.Pp
+Here are the options to specify the daemon and how it should start or stop:
+.Bl -tag -width indent
+.It Fl x , -exec Ar daemon
+The
+.Ar daemon
+we start or stop.
+If this option is not specified, then the first non option argument
+is used.
+.It Fl p , -pidfile Ar pidfile
+When starting, we expect the daemon to create a valid
+.Ar pidfile
+within a reasonable amount of time. When stopping we only stop the first pid
+listed in the
+.Ar pidfile .
+.It Fl n , -name Ar name
+Match the process
+.Ar name
+instead of a pidfile or executable.
+.It Fl i , -interpreted
+When matching process name, we should ensure that the correct interpreter
+is also matched.
+So if the daemon foo starts off like so
+.D1 #!/usr/bin/perl -w
+then
+.Nm
+matches the process
+.D1 /usr/bin/perl -w foo
+If an interpreted daemon changes its process name then this won't work.
+.It Fl u , -user Ar user Ns Op : Ns Ar group
+Start the daemon as the
+.Ar user
+and update $HOME accordingly or stop daemons
+owned by the user. You can optionally append a
+.Ar group
+name here also.
+.It Fl t , -test
+Print the action(s) that would be taken, but don't actually do anything.
+The return value is set as if the command was taken and worked.
+.It Fl v , -verbose
+Print the action(s) that are taken just before doing them.
+.It Fl P , -progress
+Echo a . to the console for each second elapsed whilst waiting.
+.El
+.Pp
+These options are only used for starting daemons:
+.Bl -tag -width indent
+.It Fl a , -startas Ar name
+Change the process name of the daemon to
+.Ar name .
+This just changes the first argument passed to the daemon.
+.It Fl b , -background
+Force the daemon into the background. Some daemons don't create pidfiles, so a
+good trick is to get the daemon to run in the foreground, and use the this
+option along with
+.Fl m , -make-pidfile
+to create a working pidfile.
+.It Fl d , -chdir Ar path
+chdir to this directory before starting the daemon.
+.It Fl r , -chroot Ar path
+chroot to this directory before starting the daemon. All other paths, such
+as the path to the daemon, chdir and pidfile, should be relative to the chroot.
+.It Fl c , -chuid Ar user
+Same as the
+.Fl u , -user
+option.
+.It Fl e , -env Ar VAR=VALUE
+Set the environment variable VAR to VALUE.
+.It Fl g , -group Ar group
+Start the daemon as in the group.
+.It Fl k , -umask Ar mode
+Set the umask of the daemon.
+.It Fl m , -make-pidfile
+Saves the pid of the daemon in the file specified by the
+.Fl p , -pidfile
+option. Only useful when used with daemons that run in the foreground and
+forced into the background with the
+.Fl -b , -background
+option.
+.It Fl I , -ionice Ar class Ns Op : Ns Ar data
+Modifies the IO scheduling priority of the daemon.
+Class can be 0 for none, 1 for real time, 2 for best effort and 3 for idle.
+Data can be from 0 to 7 inclusive.
+.It Fl N , -nicelevel Ar level
+Modifies the scheduling priority of the daemon.
+.It Fl 1 , -stdout Ar logfile
+Redirect the standard output of the process to logfile when started with
+.Fl background .
+The logfile Must be an absolute pathname, but relative to the path
+optionally given with
+.Fl r , -chroot .
+The logfile can also be a named pipe.
+.It Fl 2 , -stderr Ar logfile
+Redirect the standard error of the process to logfile when started with
+.Fl background .
+The logfile must be an absolute pathname, but relative to the path
+optionally given with
+.Fl r , -chroot .
+The logfile can also be a named pipe.
+.It Fl 3 , -stdout-logger Ar cmd
+Run cmd as a child process redirecting the standard output to the
+standard input of cmd when started with
+.Fl background .
+Cmd must be an absolute pathname, but relative to the path optionally given with
+.Fl r , -chroot .
+This process must be prepared to accept input on stdin and be able to
+log it or send it to another location.
+.It Fl 4 , -stderr-logger Ar cmd
+Run cmd as a child process and 
+Redirect the standard error of the process to the standard input of cmd
+when started with
+.Fl background .
+Cmd must be an absolute pathname, but relative to the path optionally given with
+.Fl r , -chroot .
+This process must be prepared to accept input on stdin and be able to
+log it or send it to another location.
+.It Fl w , -wait Ar milliseconds
+Wait
+.Ar milliseconds
+after starting and check that daemon is still running.
+Useful for daemons that check configuration after forking or stopping race
+conditions where the pidfile is written out after forking.
+.It Fl 2 , -stderr Ar logfile
+The same thing as
+.Fl 1 , -stdout
+but with the standard error output.
+.El
+.Pp
+These options are only used for stopping daemons:
+.Bl -tag -width indent
+.It Fl R , -retry Ar timeout | Ar signal Ns / Ns Ar timeout
+The retry specification can be either a timeout in seconds or multiple
+signal/timeout pairs (like SIGTERM/5).
+If this option is not given, the default is SIGTERM/5.
+.El
+.Sh ENVIRONMENT
+.Va SSD_IONICELEVEL
+can also set the IO scheduling priority of the daemon, but the command line
+option takes precedence.
+.Pp
+.Va SSD_NICELEVEL
+can also set the scheduling priority of the daemon, but the command line
+option takes precedence.
+.Pp
+.Va SSD_STARTWAIT
+As the
+.Fl w , -wait option above.
+.Pa /etc/rc.conf
+.Nm
+waits for to check the daemon is still running.
+.Sh NOTE
+.Nm
+uses
+.Xr getopt 3
+to parse its options, which allows it to accept the `--' option which will
+cause it to stop processing options at that point. Any subsequent arguments
+are passed as arguments to the daemon to start and used when finding a daemon
+to stop or signal.
+.Sh SEE ALSO
+.Xr chdir 2 ,
+.Xr chroot 2 ,
+.Xr getopt 3 ,
+.Xr nice 2 ,
+.Xr rc_find_pids 3
+.Sh BUGS
+.Nm
+cannot stop an interpreted daemon that no longer exists without a pidfile.
+.Sh HISTORY
+.Nm
+first appeared in Debian.
+.Pp
+This is a complete re-implementation with the process finding code in the
+OpenRC library (librc, -lrc) so other programs can make use of it.
+.Sh AUTHORS
+.An Roy Marples <roy@marples.name>

--- a/man8/supervise-daemon.8
+++ b/man8/supervise-daemon.8
@@ -1,0 +1,171 @@
+.\" Copyright (c) 2007-2015 The OpenRC Authors.
+.\" See the Authors file at the top-level directory of this distribution and
+.\" https://github.com/OpenRC/openrc/blob/master/AUTHORS
+.\"
+.\" This file is part of OpenRC. It is subject to the license terms in
+.\" the LICENSE file found in the top-level directory of this
+.\" distribution and at https://github.com/OpenRC/openrc/blob/master/LICENSE
+.\" This file may not be copied, modified, propagated, or distributed
+.\"    except according to the terms contained in the LICENSE file.
+.\"
+.Dd April 27, 2016
+.Dt supervise-DAEMON 8 SMM
+.Os OpenRC
+.Sh NAME
+.Nm supervise-daemon
+.Nd starts a daemon and restarts it if it crashes
+.Sh SYNOPSIS
+.Nm
+.Fl a , -healthcheck-timer
+.Ar seconds
+.Fl A , -healthcheck-delay
+.Ar seconds
+.Fl D , -respawn-delay
+.Ar seconds
+.Fl d , -chdir
+.Ar path
+.Fl e , -env
+.Ar var=value
+.Fl g , -group
+.Ar group
+.Fl I , -ionice
+.Ar arg
+.Fl k , -umask
+.Ar value
+.Fl m , -respawn-max
+.Ar count
+.Fl N , -nicelevel
+.Ar level
+.Fl P , -respawn-period
+.Ar seconds
+.Fl R , -retry
+.Ar arg
+.Fl r , -chroot
+.Ar chrootpath
+.Fl u , -user
+.Ar user
+.Fl 1 , -stdout
+.Ar logfile
+.Fl 2 , -stderr
+.Ar logfile
+.Fl S , -start
+.Ar daemon
+.Op Fl -
+.Op Ar arguments
+.Nm
+.Fl K , -stop
+.Ar daemon
+.Fl r , -chroot
+.Ar chrootpath
+.Sh DESCRIPTION
+.Nm
+provides a consistent method of starting, stopping and restarting
+daemons. If
+.Fl K , -stop
+is not provided, then we assume we are starting the daemon.
+.Nm
+only works with daemons which do not fork. Also, it uses its own pid
+file, so the daemon should not write a pid file, or the pid file passed
+to 
+.Nm
+should not be the one the daemon writes.
+.Pp
+Here are the options to specify the daemon and how it should start or stop:
+.Bl -tag -width indent
+.It Fl u , -user Ar user Ns Op : Ns Ar group
+Start the daemon as the
+.Ar user
+and update $HOME accordingly or stop daemons
+owned by the user. You can optionally append a
+.Ar group
+name here also.
+.It Fl v , -verbose
+Print the action(s) that are taken just before doing them.
+.Pp
+The options are as follows:
+.Bl -tag -width indent
+.Fl a , -healthcheck-timer Ar seconds
+Run the healthcheck() command, possibly followed by the unhealthy()
+command every time this number of seconds passes.
+.Fl A , -healthcheck-delay Ar seconds
+Wait this long before the first health check.
+.It Fl D , -respawn-delay Ar seconds
+wait this number of seconds before restarting a daemon after it crashes.
+The default is 0.
+.It Fl d , -chdir Ar path
+chdir to this directory before starting the daemon.
+.It Fl e , -env Ar VAR=VALUE
+Set the environment variable VAR to VALUE.
+.It Fl g , -group Ar group
+Start the daemon as in the group.
+.It Fl I , -ionice Ar class Ns Op : Ns Ar data
+Modifies the IO scheduling priority of the daemon.
+Class can be 0 for none, 1 for real time, 2 for best effort and 3 for idle.
+Data can be from 0 to 7 inclusive.
+.It Fl k , -umask Ar mode
+Set the umask of the daemon.
+.It Fl m , -respawn-max Ar count
+Sets the maximum number of times a daemon will be respawned during a
+respawn period. If a daemon dies more than this number of times during a
+respawn period,
+.Nm
+will give up trying to respawn it and exit. The default is 10, and 0
+means unlimited.
+.It Fl N , -nicelevel Ar level
+Modifies the scheduling priority of the daemon.
+.It Fl P , -respawn-period Ar seconds
+Sets the length of a respawn period. The default is 10 seconds. See the
+description of --respawn-max for more information.
+.It Fl R , -retry Ar timeout | Ar signal Ns / Ns Ar timeout
+The retry specification can be either a timeout in seconds or multiple
+signal/timeout pairs (like SIGTERM/5).
+If this option is not given, the default is SIGTERM/5.
+.It Fl r , -chroot Ar path
+chroot to this directory before starting the daemon. All other paths, such
+as the path to the daemon and chdir should be relative to the chroot.
+.It Fl u , -user Ar user
+Start the daemon as the specified user.
+.It Fl 1 , -stdout Ar logfile
+Redirect the standard output of the process to logfile.
+Must be an absolute pathname, but relative to the path optionally given with
+.Fl r , -chroot .
+The logfile can also be a named pipe.
+.It Fl 2 , -stderr Ar logfile
+The same thing as
+.Fl 1 , -stdout
+but with the standard error output.
+.El
+.Sh ENVIRONMENT
+.Va SSD_NICELEVEL
+can also set the scheduling priority of the daemon, but the command line
+option takes precedence.
+.Sh NOTE
+.Nm
+uses
+.Xr getopt 3
+to parse its options, which allows it to accept the `--' option which will
+cause it to stop processing options at that point. Any subsequent arguments
+are passed as arguments to the daemon to start and used when finding a daemon
+to stop or signal.
+.Sh NOTE
+If respawn-delay, respawn-max and respawn-period are not set correctly,
+it is possible to trigger a situation in which the supervisor will
+infinitely try to respawn a daemon. To avoid this, if you change the
+values of --respawn-delay, --respawn-max or --respawn-period, always
+make sure the settings mmake sense. For example, a respawn period of 5
+seconds with a respawn max of 10 and a respawn delay of 1 second leads
+to infinite respawning since there can never be 10 respawns within 5
+seconds.
+.Sh SEE ALSO
+.Xr chdir 2 ,
+.Xr chroot 2 ,
+.Xr getopt 3 ,
+.Xr nice 2 ,
+.Sh HISTORY
+.Nm
+first appeared in Debian.
+.Pp
+This is a complete re-implementation with the process finding code in the
+OpenRC library (librc, -lrc) so other programs can make use of it.
+.Sh AUTHORS
+.An William Hubbs <w.d.hubbs@gmail.com>


### PR DESCRIPTION
OpenRC is an rc system, used primarily in Gentoo and Alpine Linux.
The license in question is BSD-2 at the time of merge. The headers (with links to it) are kept, so the terms of the license should be fulfilled.