### PR TITLE
Add man page for yum shell

### DIFF
--- a/man8/yum-shell.8
+++ b/man8/yum-shell.8
@@ -1,0 +1,74 @@
+.\" yum shell - Yum shell interface
+.TH "yum" "8" "" "Seth Vidal" ""
+.SH "NAME"
+yum \- Yellowdog Updater Modified shell
+.SH "SYNOPSIS"
+\fByum shell\fP [filename]
+.SH "DESCRIPTION"
+.PP 
+\fByum\fP includes an interactive shell for conducting multiple commands or
+sets of commands during a single execution of yum. These commands can be
+issued manually or passed to yum from a file. The commands are much the same
+as the normal yum command line options. See here \fIyum(8)\fP for that
+information. There are a few additional commands documented below.
+
+.PP
+.IP "\fBconfig\fP"
+   [argument] [value] 
+   args: debuglevel, errorlevel, obsoletes, gpgcheck, assumeyes, exclude
+     If no value is given it prints the current value\&. 
+     If value is given it sets that value\&.
+.IP
+.IP "\fBrepo\fP"
+   [argument] [option]
+     list: lists repositories and their status
+     enable: enable repositories. option = repository id 
+     disable: disable repositories. option = repository id 
+.IP
+.IP "\fBtransaction\fP"
+   [argument]
+     list: lists the contents of the transaction 
+     reset: reset (zero-out) the transaction 
+     solve: run the dependency solver on the transaction
+     run: run the transaction 
+.IP
+.IP "\fBexit\fP"
+     Causes the shell to exit, setting the exit status as specified by the
+     \fBshell_exit_status\fR option in \fIyum.conf(5)\fR.
+     This command is also triggered when EOF is read (usually the C-d keystroke
+     or end of script).
+
+.PP 
+.SH "Examples"
+The following are examples of using the yum shell\&.
+.IP
+ list available packagename*
+ groupinfo 'Some Group'
+ install foo
+ remove bar
+ update baz
+ run
+
+That will list available packages matching the glob 'packagename*'.
+It will return information on the group 'Some Group'
+It will then queue the following commands into  the transaction: install
+foo, remove bar, update baz. Then the 'run' command will resolve dependencies
+for the transaction commands and run the transaction.
+.PP 
+.SH "SEE ALSO"
+.nf
+.I yum (8)
+http://yum.baseurl.org/
+.fi 
+
+.PP 
+.SH "AUTHORS"
+.nf 
+See the Authors file included with this program.
+.fi 
+
+.PP 
+.SH "BUGS"
+There of course aren't any bugs, but if you find any, they should be sent
+to the mailing list: yum@lists.baseurl.org or filed in bugzilla.
+.fi


### PR DESCRIPTION
In Fedora the equivalent functionality (dnf shell) is covered in the [main dnf man page](https://www.mankier.com/8/dnf#Commands-Shell_Command), but in RHEL/CentOS prior to 8 it is still a separate man page.  This was pull directly from the upstream repo.

https://github.com/rpm-software-management/yum/blob/master/docs/yum-shell.8