### PR TITLE
Add the rest of the yum man pages

### DIFF
--- a/man5/yum-updatesd.conf.5
+++ b/man5/yum-updatesd.conf.5
@@ -1,0 +1,70 @@
+.TH "yum-updatesd.conf" "5" "" "Jeremy Katz" "yum-updatesd configuration file"
+.SH "NAME"
+.LP 
+\fByum-updatesd.conf\fR \- Configuration file for \fByum-updatesd(8)\fR.
+.SH "DESCRIPTION"
+.LP 
+yum-updatesd uses a configuration file at \fB/etc/yum/yum-updatesd.conf\fR. 
+.LP
+Additional configuration information is read from the main \fByum.conf
+(5)\fR configuration file.
+
+.SH "PARAMETERS"
+.LP
+There is one section in the yum-updatesd configuration file, main,
+which defines all of the global configuration options.
+
+.SH "[main] OPTIONS"
+.LP 
+The [main] section must exist for yum-updatesd to do anything. It
+consists of the following options:
+
+.IP \fBrun_interval\fR
+Number of seconds to wait between checks for available updates.
+
+.IP \fBupdaterefresh\fR
+Minimum number of seconds between update information refreshes to
+avoid hitting the server too often.
+
+.IP \fBemit_via\fR
+List of ways to emit update notification.  Valid values are `email',
+`dbus' and `syslog'.
+
+.IP \fBdo_update\fR
+Boolean option to decide whether or not updates should be
+automatically applied.  Defaults to False.
+
+.IP \fBdo_download_deps\fR
+Boolean option to decide whether or not updates should be
+automatically downloaded.  Defaults to False.
+
+.IP \fBdo_download_deps\fR
+Boolean option to automatically download dependencies of packages which need
+updating as well.  Defaults to False.
+
+.SH "MAIL OPTIONS"
+.IP \fBemail_to\fR
+List of email addresses to send update notification to.  Defaults to 
+`root@localhost'.
+
+.IP \fBemail_from\fR
+Email address for update notifications to be from.  Defaults to 
+`yum-updatesd@localhost'.
+
+.SH "SYSLOG OPTIONS"
+.IP \fBsyslog_facility\fR
+What syslog facility should be used.  Defaults to `DAEMON'.
+
+.IP \fBsyslog_level\fR
+Level of syslog messages.  Defaults to `WARN'.
+
+
+.SH "FILES"
+.nf 
+/etc/yum/yum-updatesd.conf
+
+.SH "SEE ALSO"
+.LP 
+yum-updatesd(8)
+yum.conf(5)
+

--- a/man5/yum.conf.5
+++ b/man5/yum.conf.5
@@ -1,0 +1,1391 @@
+.TH "yum.conf" "5" "" "Seth Vidal" "yum configuration file"
+.SH "NAME"
+.LP 
+\fByum.conf\fR \- Configuration file for \fByum(8)\fR.
+.SH "DESCRIPTION"
+.LP
+Yum uses a configuration file at \fB/etc/yum/yum.conf\fR.
+.LP
+Additional configuration files are also read from the directories set by the
+\fBreposdir\fR option (default is `/etc/yum/repos.d').
+See the \fBreposdir\fR option below for further details.
+
+.SH "PARAMETERS"
+.LP 
+There are two types of sections in the yum configuration file(s): main and
+repository. Main defines all global configuration options. There should be only
+one main section. The repository section(s) define the configuration for each
+repository/server. There should be one or more repository sections.
+
+.SH "[main] OPTIONS"
+.LP 
+The [main] section must exist for yum to do anything. It consists of the
+following options:
+
+.IP
+\fBcachedir\fR
+Directory where yum should store its cache and db files. The default is
+`/var/cache/yum'.
+
+.IP
+\fBcashe_root_dir\fR
+Directory where yum would initialize the cashe, should almost certainly be left
+at the default. The default is`/var/cache/CAShe'. Note that unlike all other
+configuration, this does not change with installroot, the reason is so that
+multiple install root can share the same data. See man cashe for more info.
+
+.IP
+\fBpersistdir\fR
+Directory where yum should store information that should persist over multiple
+runs. The default is `/var/lib/yum'.
+
+.IP
+\fBkeepcache\fR
+Either `1' or `0'. Determines whether or not yum keeps the cache
+of headers and packages after successful installation.  Default is '1'
+(keep files)
+.br
+
+.IP
+\fBusercache\fR
+Either `1' or `0'. Determines whether or not yum should store per-user cache in
+$TMPDIR.
+When set to `0', then whenever yum runs as a non\-root user,
+\fB\-\-cacheonly\fR is implied and system cache is used directly, and no new
+user cache is created in $TMPDIR.
+This can be used to prevent $TMPDIR from filling up if many users on the system
+often use yum and root tends to have up-to-date metadata that the users can
+rely on (they can still enable this feature with \fB\-\-setopt\fR if they
+wish).
+Default is `1' (user cache enabled).
+
+.IP
+\fBreposdir\fR
+A list of directories where yum should look for .repo files which define
+repositories to use. Default is `/etc/yum/repos.d'. Each
+file in this directory should contain one or more repository sections as
+documented in \fB[repository] options\fR below. These will be merged with the
+repositories defined in /etc/yum/yum.conf to form the complete set of
+repositories that yum will use.
+
+.IP
+\fBdebuglevel\fR
+Debug message output level. Practical range is 0\-10. Default is `2'.
+
+.IP
+\fBerrorlevel\fR
+Error message output level. Practical range is 0\-10. Default is `2'.
+
+.IP
+\fBrpmverbosity\fR
+Debug scriptlet output level. 'info' is the default, other
+options are: 'critical', 'emergency', 'error', 'warn' and 'debug'.
+
+.IP
+\fBprotected_packages\fR
+This is a list of packages that yum should never completely remove. They are
+protected via Obsoletes as well as user/plugin removals.
+
+The default is: yum glob:/etc/yum/protected.d/*.conf
+So any packages which should be protected can do so by including a file in 
+/etc/yum/protected.d with their package name in it.
+
+Also if this configuration is set to anything, then yum will protect the
+package corresponding to the running version of the kernel.
+
+.IP
+\fBprotected_multilib\fR
+Either `1' or `0'. This tells yum whether or not it should perform a check to
+make sure that multilib packages are the same version. For example, if this
+option is off (rpm behavior) then in some cases it might be possible for
+pkgA-1.x86_64 and pkgA-2.i386 to be installed at the same time. However this
+is very rarely desired. Install only packages, like the kernel, are exempt
+from this check.
+The default is `1'.
+
+.IP
+\fBlogfile\fR
+Full directory and file name for where yum should write its log file.
+
+.IP
+\fBgpgcheck\fR
+Either `1' or `0'. This tells yum whether or not it should perform a GPG
+signature check on packages. When this is set in the [main] section it sets the
+default for all repositories. 
+The default is `0'.
+
+\fBlocalpkg_gpgcheck\fR
+Either `1' or `0'. This tells yum whether or not it should perform a GPG
+signature check on local packages (packages in a file, not in a repositoy).
+The default is `0'.
+
+.IP
+\fBrepo_gpgcheck\fR
+Either `1' or `0'. This tells yum whether or not it should perform a GPG
+signature check on the repodata. When this is set in the [main] section it sets the
+default for all repositories. The default is `0'.
+
+.IP
+\fBskip_broken\fR
+Either `1' or `0'. Resolve depsolve problems by removing packages that
+are causing problems from the transaction.
+
+.IP
+\fBassumeyes\fR
+Either `1' or `0'. Determines whether or not yum prompts for confirmation of
+critical actions. Default is `0' (do prompt).
+.br
+Command-line option: \fB\-y\fP \fB\--assumeyes\fP
+
+.IP
+\fBassumeno\fR
+Either `1' or `0'. If yum would prompt for confirmation of critical actions, 
+assume the user chose no. This is basically the same as doing "echo | yum ..."
+but is a bit more usable. This option overrides \fBassumeyes\fP, but is still
+subject to \fBalwaysprompt\fP.
+Default is `0' (do prompt).
+.br
+Command-line option: \fB\--assumeno\fP
+
+.IP
+\fBalwaysprompt\fR
+Either `1' or `0'. When set to `0', yum will not prompt for confirmation
+when the list of packages to be installed exactly matches those given on the
+command line. Unless \fBassumeyes\fR is enabled, it will prompt when
+additional packages need to be installed to fulfill dependencies
+regardless of this setting. Note that
+older versions of yum would also always prompt for package removal, and that is
+no longer true.
+Default is `1'.
+.br
+
+.IP
+\fBtolerant\fR
+Either `1' or `0'. If enabled, yum will go slower, checking for things that
+shouldn't be possible making it more tolerant of external errors.
+Default to `0' (not tolerant).
+.br
+Command-line option: \fB\-t\fP
+
+.IP
+\fBexclude\fR
+List of packages to exclude from all repositories, so yum works
+as if that package was never in the repositories. This should be a space
+separated list.
+This is commonly used so a package isn't upgraded or installed accidentally, but
+can be used to remove packages in any way that "yum list" will show packages.
+Shell globs using wildcards (eg. * and ?) are allowed.
+
+Can be disabled using disable_excludes or --disableexcludes.
+Command-line option: \fB\-x\fP
+
+.IP
+\fBdisable_excludes\fR
+A way to permanently set the --disableexcludes command line option.
+
+.IP
+\fBquery_install_excludes\fR
+This applies the command line exclude option (only, not the configuration
+exclude above) to installed packages being shown in some query commands
+(currently: list/info/search/provides). Default is '0'.
+
+.IP
+\fBinstallonlypkgs \fR
+List of package provides that should only ever be installed, never updated.
+Kernels in particular fall into this category. Defaults to kernel,
+kernel-bigmem, kernel-enterprise, kernel-smp, kernel-modules, kernel-debug, 
+kernel-unsupported, kernel-source, kernel-devel, kernel-PAE, kernel-PAE-debug.
+
+Note that because these are provides, and not just package names, kernel-devel
+will also apply to kernel-debug-devel, etc.
+
+.IP
+\fBinstallonly_limit \fR
+Number of packages listed in installonlypkgs to keep installed at the same
+time. Setting to 0 disables this feature. Default is '0'. Note that this
+functionality used to be in the "installonlyn" plugin, where this option was
+altered via tokeep.
+Note that as of version 3.2.24, yum will now look in the yumdb for a installonly
+attribute on installed packages. If that attribute is "keep", then they will
+never be removed.
+
+.IP
+\fBkernelpkgnames \fR
+List of package names that are kernels. This is really only here for the
+updating of kernel packages and should be removed out in the yum 2.1 series.
+
+.IP
+\fBexactarchlist\fR
+List of packages that should never change archs in an update.
+That means, if a package has a newer version available which is for a different
+compatible arch, yum will not consider that version an update if the package
+name is in this list.
+For example, on x86_64, foo-1.x86_64 won't be updated to foo-2.i686 if foo is
+in this list.
+Kernels in particular fall into this category.
+Shell globs using wildcards (eg. * and ?) are allowed.
+Defaults to kernel, kernel-smp, kernel-hugemem, kernel-enterprise,
+kernel-bigmem, kernel-devel, kernel-PAE, kernel-PAE-debug.
+
+.IP
+\fBshowdupesfromrepos\fR
+Either `0' or `1'. Set to `1' if you wish to show any duplicate packages from
+any repository, from package listings like the info or list commands. Set
+to `0' if you want only to see the newest packages from any repository.
+Default is `0'.
+
+.IP
+\fBobsoletes \fR
+This option only has affect during an \fBupdate\fR. It enables yum's
+obsoletes processing logic. Useful when doing distribution level upgrades. See
+also the yum \fBupgrade\fR command documentation for more details (yum(8)).
+Default is `true'.
+.br
+Command-line option: \fB\-\-obsoletes\fP
+
+.IP
+\fBremove_leaf_only \fR
+Either `0' or `1'. Used to determine yum's behaviour when a package is removed.
+If \fBremove_leaf_only\fR is `0' (default) then
+packages, and their deps, will be removed.  If \fBremove_leaf_only\fR is
+`1' then only those packages that aren't required by another
+package will be removed.
+
+.IP
+\fBrepopkgsremove_leaf_only \fR
+Either `0' or `1'. Used to determine yum's behaviour when the repo-pkg remove
+command is run.  If \fBrepopkgremove_leaf_only\fR is `0' (default) then
+all packages in the repo. will be removed.  If \fBrepopkgremove_leaf_only\fR is
+`1' then only those packages in the repo. that aren't required by another
+package will be removed.
+Note that this option does not override remove_leaf_only, so enabling that
+option means this has almost no affect.
+
+.IP
+\fBoverwrite_groups \fR
+Either `0' or `1'. Used to determine yum's behaviour if two or more
+repositories offer the package groups with the same name. If
+\fBoverwrite_groups\fR is `1' then the group packages of the last matching
+repository will be used. If \fBoverwrite_groups\fR is `0' then the groups
+from all matching repositories will be merged together as one large group.
+Note that this option does not override remove_leaf_only, so enabling that
+option means this has almost no affect.
+
+.IP
+\fBgroupremove_leaf_only \fR
+Either `0' or `1'. Used to determine yum's behaviour when the groupremove
+command is run.  If \fBgroupremove_leaf_only\fR is `0' (default) then
+all packages in the group will be removed.  If \fBgroupremove_leaf_only\fR is
+`1' then only those packages in the group that aren't required by another
+package will be removed.
+
+.IP
+\fBenable_group_conditionals\fR
+Either `0' or `1'. Determines whether yum will allow the use of conditionals
+packages. Default is `1' (package conditionals are allowed).
+
+.IP
+\fBgroup_package_types\fR
+List of the following: optional, default, mandatory. Tells yum which type
+of packages in groups will be installed when 'groupinstall' is called. 
+Default is: default, mandatory
+
+.IP
+\fBgroup_command\fR
+List of the following: simple, compat, objects. Tells yum what to do for
+group install/upgrade/remove commands.
+
+Simple acts like you did yum group cmd $(repoquery --group --list group), so
+it is very easy to reason about what will happen. Alas. this is often not what
+people want to happen.
+
+Compat. works much like simple, except that when you run "group upgrade" it
+actually runs "group install" (this means that you get any new packages added
+to the group, but you also get packages added that were there before and you
+didn't want).
+
+Objects makes groups act like a real object, separate from the packages they
+contain. Yum keeps track of the groups you have installed, so "group upgrade"
+will install new packages for the group but not install old ones. It also knows
+about group members that are installed but weren't installed as part of the
+group, and won't remove those on "group remove".
+Running "yum upgrade" will also run "yum group upgrade" (thus. adding new
+packages for all groups).
+
+Default is: compat
+
+.IP
+\fBupgrade_group_objects_upgrade\fR
+Either `0' or `1'. Set this to `0' to disable the automatic running of
+"group upgrade" when running the "upgrade" command, and group_command is set to
+"objects". Default is `1' (perform the operation).
+
+.IP
+\fBautocheck_running_kernel\fR
+Either `0' or `1'. Set this to `0' to disable the automatic checking of the
+running kernel against updateinfo ("yum updateinfo check-running-kernel"), in
+the "check-update" and "updateinfo summary" commands.
+Default is `1' (perform the check).
+
+.IP
+\fBinstallroot \fR
+Specifies an alternative installroot, relative to which all packages will be
+installed. 
+.br
+Command-line option: \fB\-\-installroot\fP
+
+.IP
+\fBconfig_file_path \fR
+Specifies the path to main the configuration file.
+Default is /etc/yum/yum.conf.
+
+.IP
+\fBcheck_config_file_age \fR
+Either `0' or `1'. Specifies whether yum should auto metadata expire repos. 
+that are older than any of the configuration files that led to them (usually 
+the yum.conf file and the foo.repo file).
+Default is `1' (perform the check).
+
+.IP
+\fBdistroverpkg\fR
+The package used by yum to determine the "version" of the distribution, this
+sets $releasever for use in config. files. This
+can be any installed package. Default is `system-release(releasever)',
+`redhat-release'. Yum will now look at the version provided by the provide,
+and if that is non-empty then will use the full V(-R), otherwise it uses the
+version of the package.
+ You can see what provides this manually by using: 
+"yum whatprovides 'system-release(releasever)' redhat-release" and you can see
+what $releasever is most easily by using: "yum version".
+
+.IP
+\fBdiskspacecheck\fR
+Either `0' or `1'. Set this to `0' to disable the checking for sufficient
+diskspace and inodes before a RPM transaction is run. Default is `1'
+(perform the check).
+
+.IP
+\fBtsflags\fR
+Comma or space separated list of transaction flags to pass to the rpm
+transaction set. These include 'noscripts', 'notriggers', 'nodocs', 'test', 'justdb' and 'nocontexts'. 'repackage' is also available but that does nothing
+with newer rpm versions.
+You can set all/any of them. However, if you don't know what these do in the
+context of an rpm transaction set you're best leaving it alone. Default is
+an empty list.
+Also see the "yum fs" command, for excluding docs.
+
+.IP
+\fBoverride_install_langs\fR
+This is a way to override rpm's _install_langs macro. without having to change
+it within rpm's macro file.
+Default is nothing (so does nothing).
+Also see the "yum fs" command.
+
+.IP
+\fBrecent\fR
+Number of days back to look for `recent' packages added to a repository.
+Used by the \fBlist recent\fR command. Default is `7'.
+
+.IP
+\fBretries\fR
+Set the number of times any attempt to retrieve a file should retry before 
+returning an error. Setting this to `0' makes yum try forever. Default is `10'.
+
+.IP
+\fBkeepalive \fR
+Either `0' or `1'. Set whether HTTP keepalive should be used for HTTP/1.1
+servers that support it. This can improve transfer speeds by using one
+connection when downloading multiple files from a repository. Default is `1'.
+
+.IP
+\fBtimeout \fR
+Number of seconds to wait for a connection before timing out. Defaults to
+30 seconds. This may be too short of a time for extremely overloaded
+sites.
+
+.IP
+\fBhttp_caching\fR
+Determines how upstream HTTP caches are instructed to handle any HTTP downloads
+that Yum does. This option can take the following values:
+
+`all' means that all HTTP downloads should be cached.
+
+`packages' means that only RPM package downloads should be cached (but not
+repository metadata downloads).
+
+`lazy:packages' means that act like `packages' unless package verification
+fails (e.g. the package download doesn't match the expected checksum), in which
+case try re-downloading the package as if `none' was set.  This value is a good
+compromise if you want to avoid issues caused by stale proxy cache after remote
+RPMs change contents without changing filenames (e.g. are pushed unsigned and
+later signed) but still want the benefits of package caching whenever possible.
+
+`none' means that no HTTP downloads should be cached.
+
+The default is `all'. This is recommended unless you are experiencing caching
+related issues. Try to at least use `packages' to minimize load on repository
+servers.
+
+.IP
+\fBthrottle \fR
+Enable bandwidth throttling for downloads. This option can be expressed as a
+absolute data rate in bytes/sec. An SI prefix (k, M or G) may be appended to the
+bandwidth value (eg. `5.5k' is 5.5 kilobytes/sec, `2M' is 2 Megabytes/sec).
+
+Alternatively, this option can specify the percentage of total bandwidth to use 
+(eg. `60%'). In this case the \fBbandwidth\fR option should be used to specify
+the maximum available bandwidth.
+
+Set to `0' to disable bandwidth throttling. This is the default.
+
+Note that when multiple downloads run simultaneously the total bandwidth might
+exceed the throttle limit. You may want to also set max_connections=1 or scale
+your throttle option down accordingly.
+
+.IP
+\fBminrate \fR
+This sets the low speed threshold in bytes per second. If the server
+is sending data slower than this for at least `timeout' seconds, Yum
+aborts the connection. The default is `1000'.
+
+.IP
+\fBbandwidth \fR
+Use to specify the maximum available network bandwidth in bytes/second.  Used
+with the \fBthrottle\fR option (above). If \fBthrottle\fR is a percentage and
+\fBbandwidth\fR is `0' then bandwidth throttling will be disabled. If
+\fBthrottle\fR is expressed as a data rate (bytes/sec) then this option is
+ignored. Default is `0' (no bandwidth throttling). 
+
+.IP
+\fBip_resolve \fR
+Determines how yum resolves host names.
+
+`4' or `IPv4': resolve to IPv4 addresses only.
+
+`6' or `IPv6': resolve to IPv6 addresses only.
+
+.IP
+\fBmax_connections \fR
+
+The maximum number of simultaneous connections.  This overrides the urlgrabber
+default of 5 connections.  Note that there are also implicit per-mirror limits
+and the downloader honors these too.
+
+.IP
+\fBftp_disable_epsv \fR
+This options disables Extended Passive Mode (the EPSV command) which does not
+work correctly on some buggy ftp servers. Default is `0' (EPSV enabled).
+
+.IP
+\fBdeltarpm\fR
+
+When non-zero, delta-RPM files are used if available.  The value specifies
+the maximum number of "applydeltarpm" processes Yum will spawn, if the value
+is negative then yum works out how many cores you have and multiplies that
+by the value (cores=2, deltarpm=-2; 4 processes). (2 by default).
+
+Note that the "applydeltarpm" process uses a significant amount of disk IO,
+so running too many instances can significantly slow down all disk IO including
+the downloads that yum is doing (thus. a too high value can make everything
+slower).
+
+.IP
+\fBdeltarpm_percentage\fR
+When the relative size of delta vs pkg is larger than this, delta is not used.
+Default value is 75 (Deltas must be at least 25% smaller than the pkg).
+Use `0' to turn off delta rpm processing. Local repositories (with file://
+baseurl) have delta rpms turned off by default.
+
+.IP
+\fBdeltarpm_metadata_percentage\fR
+When the relative size of deltarpm metadata vs pkgs is larger than this,
+deltarpm metadata is not downloaded from the repo.
+Default value is 100 (Deltarpm metadata must be smaller than the packages from
+the repo). Note that you can give values over 100, so 200 means that the
+metadata is required to be half the size of the packages.
+Use `0' to turn off this check, and always download metadata.
+
+.IP
+\fBsslcacert \fR
+Path to the directory containing the databases of the certificate authorities
+yum should use to verify SSL certificates. Defaults to none - uses system
+default
+
+.IP
+\fBsslverify \fR
+Boolean - should yum verify SSL certificates/hosts at all. Defaults to True.
+
+Note that the plugin yum-rhn-plugin will force this value to true, and may
+alter other ssl settings (like hostname checking), even if it the machine
+is not registered.
+
+.IP
+\fBsslclientcert \fR
+Path to the SSL client certificate yum should use to connect to repos/remote sites
+Defaults to none.
+
+Note that if you are using curl compiled against NSS (default in Fedora/RHEL),
+curl treats sslclientcert values with the same basename as _identical_. This
+version of yum will check that this isn't true and output an error when the
+repositories "foo" and "bar" violate this, like so:
+
+sslclientcert basename shared between foo and bar
+
+.IP
+\fBsslclientkey \fR
+Path to the SSL client key yum should use to connect to repos/remote sites
+Defaults to none.
+
+.IP
+\fBssl_check_cert_permissions \fR
+Boolean - Whether yum should check the permissions on the paths for the
+certificates on the repository (both remote and local). If we can't read any of
+the files then yum will force skip_if_unavailable to be true.
+This is most useful for non-root processes which use yum on repos. that have
+client cert files which are readable only by root.
+Defaults to True.
+
+.IP
+\fBhistory_record \fR
+Boolean - should yum record history entries for transactions. This takes some
+disk space, and some extra time in the transactions. But it allows how to know a
+lot of information about what has happened before, and display it to the user
+with the history info/list/summary commands. yum also provides the
+history undo/redo commands. Defaults to True.
+
+Note that if history is recorded, yum uses that information to see if any
+modifications to the rpmdb have been done outside of yum. These are always bad,
+from yum's point of view, and so yum will issue a warning and automatically
+run some of "yum check" to try and find some of the worst problems altering
+the rpmdb might have caused.
+.IP
+This means that turning this option off will stop yum from being able to
+detect when the rpmdb has changed and thus. it will never warn you or
+automatically run "yum check". The problems will likely still be there, and
+yumdb etc. will still be wrong but yum will not warn you about it.
+
+.IP
+\fBhistory_record_packages \fR
+This is a list of package names that should be recorded as having helped the
+transaction. yum plugins have an API to add themselves to this, so it should not
+normally be necessary to add packages here. Not that this is also used for the
+packages to look for in \-\-version. Defaults to rpm, yum, yum-metadata-parser.
+
+.IP
+\fBhistory_list_view \fR
+Which column of information to display in the "yum history list" command. There
+are currently three options: users, cmds (or commands), auto.
+
+Older versions of yum acted like "users", which always outputs the user who
+initiated the yum transaction. You can now specify "commands" which will instead
+always output the command line of the transaction. You can also specify
+"single-user-commands" which will display the users if there are more than one,
+otherwise it will display the command line.
+
+You can also specify "default" which currently selects "single-user-commands".
+
+.IP
+\fBcommands\fR
+List of functional commands to run if no functional commands are specified
+on the command line (eg. "update foo bar baz quux").  None of the short options
+(eg. \-y, \-e, \-d) are accepted for this option.
+
+.IP
+\fBsyslog_ident \fR
+Identification (program name) for syslog messages.
+
+.IP
+\fBsyslog_facility \fR
+Facility name for syslog messages, see syslog(3).  Default is `LOG_USER'.
+
+.IP
+\fBsyslog_device \fR
+Where to log syslog messages. Can be a local device (path) or a host:port
+string to use a remote syslog.  If empty or points to a nonexistent device,
+syslog logging is disabled.  Default is `/dev/log'.
+
+.IP
+\fBproxy \fR
+URL to the proxy server that yum should use.  Set this to `libproxy'
+to enable proxy auto configuration via libproxy.  Defaults to direct
+connection.
+
+.IP
+\fBproxy_username \fR
+username to use for proxy
+
+.IP
+\fBproxy_password \fR
+password for this proxy
+
+.IP
+\fBusername \fR
+username to use for basic authentication to a repo or really any url.
+
+.IP
+\fBpassword \fR
+password to use with the username for basic authentication.
+
+.IP
+\fBplugins \fR
+Either `0' or `1'. Global switch to enable or disable yum plugins. Default is
+`0' (plugins disabled). See the \fBPLUGINS\fR section of the \fByum(8)\fR man
+for more information on installing yum plugins.
+
+.IP
+\fBpluginpath \fR
+A list of directories where yum should look for plugin modules. Default is
+`/usr/share/yum-plugins' and `/usr/lib/yum-plugins'.
+
+.IP
+\fBpluginconfpath \fR
+A list of directories where yum should look for plugin configuration files.
+Default is `/etc/yum/pluginconf.d'.
+
+.IP
+\fBmetadata_expire \fR
+Time (in seconds) after which the metadata will expire. So that if the
+current metadata downloaded is less than this many seconds old then yum will
+not update the metadata against the repository.  If you find that
+yum is not downloading information on updates as often as you would like
+lower the value of this option. You can also change from the default of using
+seconds to using days, hours or minutes by appending a d, h or m respectively.
+The default is 6 hours, to compliment yum-updatesd running once an hour.
+It's also possible to use the word "never", meaning that the metadata will
+never expire. Note that when using a metalink file the metalink must always
+be newer than the metadata for the repository, due to the validation, so this
+timeout also applies to the metalink file.
+Also note that "never" does not override "yum clean expire-cache"
+
+.IP
+\fBmetadata_expire_filter \fR
+Filter the metadata_expire time, allowing a trade of speed for accuracy if
+a command doesn't require it. Each yum command can specify that it requires a
+certain level of timeliness quality from the remote repos. from "I'm about to
+install/upgrade, so this better be current" to "Anything that's available
+is good enough".
+
+`never' - Nothing is filtered, always obey metadata_expire.
+
+`read-only:past' - Commands that only care about past information
+are filtered from metadata expiring.
+Eg. yum history info (if history needs to lookup anything about a previous
+transaction, then by definition the remote package was available in the past).
+
+`read-only:present' - Commands that are balanced between past and future.
+This is the default.
+Eg. yum list yum
+
+`read-only:future' - Commands that are likely to result in running other
+commands which will require the latest metadata. Eg. yum check-update
+
+Note that this option requires that all the enabled repositories be roughly the
+same freshness (meaning the cache age difference from one another is at most 5
+days).  Failing that, metadata_expire will always be obeyed, just like with
+`never'.
+
+Also note that this option does not override "yum clean expire-cache".
+
+.IP
+\fBmirrorlist_expire \fR
+Time (in seconds) after which the mirrorlist locally cached will expire. 
+If the current mirrorlist is less than this many seconds old then yum
+will not download another copy of the mirrorlist, it has the same extra format
+as metadata_expire.
+If you find that yum is not downloading the mirrorlists as 
+often as you would like lower the value of this option.
+
+.IP
+\fBmdpolicy \fR
+You can select from different metadata download policies depending on how much
+data you want to download with the main repository metadata index. The
+advantages of downloading more metadata with the index is that you can't get
+into situations where you need to use that metadata later and the versions
+available aren't compatible (or the user lacks privileges) and that if the
+metadata is corrupt in any way yum will revert to the previous metadata.
+
+`instant' - Just download the new metadata index, this is roughly what yum
+always did, however it now does some checking on the index and reverts if
+it classifies it as bad.
+
+`group:primary' - Download the primary metadata with the index. This contains
+most of the package information and so is almost always required anyway.
+
+`group:small' - With the primary also download the updateinfo metadata, groups,
+and pkgtags. This is required for yum-security operations and it also used in
+the graphical clients. This file also tends to be significantly smaller than
+most others. This is the default.
+
+`group:main' - With the primary and updateinfo download the filelists metadata
+and the group metadata. The filelists data is required for operations like
+"yum install /bin/bash", and also some dependency resolutions require it. The
+group data is used in some graphical clients and for group operations like
+"yum grouplist Base".
+
+`group:all' - Download all metadata listed in the index, currently the only one
+not listed above is the other metadata, which contains the changelog information
+which is used by yum-changelog. This is what "yum makecache" uses.
+
+.IP
+\fBmddownloadpolicy \fR
+You can select which kinds of repodata you would prefer yum to download:
+
+`sqlite' - Download the .sqlite files, if available. This is currently slightly
+faster, once they are downloaded. However these files tend to be bigger, and
+thus. take longer to download.
+
+`xml' - Download the .XML files, which yum will do anyway as a fallback on
+the other options. These files tend to be smaller, but they require
+parsing/converting locally after download and some aditional checks are
+performed on them each time they are used.
+
+.IP
+\fBmultilib_policy \fR
+Can be set to 'all' or 'best'. All means install all possible arches for any package you 
+want to install. Therefore yum install foo will install foo.i386 and foo.x86_64 on x86_64, 
+if it is available. Best means install the best arch for this platform, only.
+
+.IP
+\fBrequires_policy \fR
+Can be set to 'strong', 'weak' or info'. Strong means install just the needed
+requirements. Weak means also install any weak requirements. Info means install
+all requirements. This only happens on install/reinstall, upgrades/downgrades
+do not consult this at all.
+Note that yum will try to just drop weak and info requirements on errors.
+
+.IP
+\fBbugtracker_url \fR
+URL where bugs should be filed for yum. Configurable for local versions or distro-specific
+bugtrackers.
+
+.IP
+\fBcolor \fR
+Whether to display colorized output automatically, depending on the output
+terminal, can be changed to always (using ANSI codes) or never.
+Default is `auto'.
+Possible values are: auto, never, always.
+Command-line option: \fB\-\-color\fP
+
+.IP
+\fBcolor_list_installed_older \fR
+The colorization/highlighting for packages in list/info installed which are
+older than the latest available package with the same name and arch.
+Default is `bold'.
+Possible values are a comma separated list containing: bold, blink, dim,
+reverse, underline, fg:black, fg:red, fg:green, fg:yellow, fg:blue, fg:magenta,
+fg:cyan, fg:white, bg:black, bg:red, bg:green, bg:yellow, bg:blue, bg:magenta,
+bg:cyan, bg:white.
+
+.IP
+\fBcolor_list_installed_newer \fR
+The colorization/highlighting for packages in list/info installed which are
+newer than the latest available package with the same name and arch.
+Default is `bold,yellow'.
+See color_list_installed_older for possible values.
+
+.IP
+\fBcolor_list_installed_reinstall \fR
+The colorization/highlighting for packages in list/info installed which is
+the same version as the latest available package with the same name and arch.
+Default is `normal'.
+See color_list_installed_older for possible values.
+
+.IP
+\fBcolor_list_installed_running_kernel \fR
+The colorization/highlighting for kernel packages in list/info installed which
+is the same version as the running kernel.
+Default is `bold,underline.
+See color_list_installed_older for possible values.
+
+.IP
+\fBcolor_list_installed_extra \fR
+The colorization/highlighting for packages in list/info installed which has
+no available package with the same name and arch.
+Default is `bold,red'.
+See color_list_installed_older for possible values.
+
+.IP
+\fBcolor_list_available_upgrade \fR
+The colorization/highlighting for packages in list/info available which is
+an upgrade for the latest installed package with the same name and arch.
+Default is `bold,blue'.
+See color_list_installed_older for possible values.
+
+.IP
+\fBcolor_list_available_downgrade \fR
+The colorization/highlighting for packages in list/info available which is
+a downgrade for the latest installed package with the same name and arch.
+Default is `dim,cyan'.
+See color_list_installed_older for possible values.
+
+.IP
+\fBcolor_list_available_install \fR
+The colorization/highlighting for packages in list/info available which has
+no installed package with the same name and arch.
+Default is `normal'.
+See color_list_installed_older for possible values.
+
+.IP
+\fBcolor_list_available_reinstall \fR
+The colorization/highlighting for packages in list/info available which is
+the same version as the installed package with the same name and arch.
+Default is `bold,underline,green.
+See color_list_installed_older for possible values.
+
+.IP
+\fBcolor_list_available_running_kernel \fR
+The colorization/highlighting for kernel packages in list/info available which
+is the same version as the running kernel.
+Default is `bold,underline.
+See color_list_installed_older for possible values.
+
+.IP
+\fBcolor_search_match \fR
+The colorization/highlighting for text matches in search.
+Default is `bold'.
+See color_list_installed_older for possible values.
+
+.IP
+\fBcolor_update_installed \fR
+The colorization/highlighting for packages in the "updates list" which are
+installed. The updates list is what is printed when you run "yum update",
+"yum list updates", "yum list obsoletes" and "yum check-update".
+Default is `normal'.
+See color_list_installed_older for possible values.
+
+.IP
+\fBcolor_update_local \fR
+The colorization/highlighting for packages in the "updates list" which are
+already downloaded. The updates list is what is printed when you run
+"yum update", "yum list updates", "yum list obsoletes" and "yum check-update".
+Default is `bold'.
+See color_list_installed_older for possible values.
+
+.IP
+\fBcolor_update_remote \fR
+The colorization/highlighting for packages in the "updates list" which need to
+be downloaded. The updates list is what is printed when you run "yum update",
+"yum list updates", "yum list obsoletes" and "yum check-update".
+Default is `normal'.
+See color_list_installed_older for possible values.
+
+.IP
+\fBui_repoid_vars \fR
+When a repository id is displayed, append these yum variables to the string
+if they are used in the baseurl/etc. Variables are appended in the order
+listed (and found).
+Default is 'releasever basearch'.
+
+.IP
+\fBclean_requirements_on_remove \fR
+When removing packages (by removal, update or obsoletion) go through each
+package's dependencies. If any of them are no longer required by any other 
+package then also mark them to be removed.
+Boolean (1, 0, True, False, yes, no) Defaults to False
+
+.IP
+\fBupgrade_requirements_on_install \fR
+When installing/reinstalling/upgrading packages go through each package's
+installed dependencies and check for an update.
+Boolean (1, 0, True, False, yes,no) Defaults to False
+
+.IP
+\fBrecheck_installed_requires \fR
+When upgrading a package do we recheck any requirements that existed in the old
+package. Turning this on shouldn't do anything but slow yum depsolving down,
+however using rpm --nodeps etc. can break the rpmdb and then this will help.
+Boolean (1, 0, True, False, yes,no) Defaults to False
+
+.IP
+\fBreset_nice \fR
+If set to true then yum will try to reset the nice value to zero, before
+running an rpm transaction. Defaults to True.
+
+\fBexit_on_lock\fR
+Should the yum client exit immediately when something else has the lock.
+Boolean (1, 0, True, False, yes, no) Defaults to False
+
+.IP
+\fBloadts_ignoremissing\fR
+Should the load-ts command ignore packages that are missing. This includes
+packages in the TS to be removed, which aren't installed, and packages in the
+TS to be added, which aren't available.
+If this is set to true, and an rpm is missing then loadts_ignorenewrpm is
+automatically set to true.
+Boolean (1, 0, True, False, yes, no) Defaults to False
+
+.IP
+\fBloadts_ignorerpm\fR
+Should the load-ts command ignore the rpmdb version (yum version nogroups) or
+abort if there is a mismatch between the TS file and the current machine.
+If this is set to true, then loadts_ignorenewrpm is automatically set to true.
+Boolean (1, 0, True, False, yes, no) Defaults to False
+
+.IP
+\fBloadts_ignorenewrpm\fR
+Should the load-ts command ignore the future rpmdb version or
+abort if there is a mismatch between the TS file and what will happen on the
+current machine.
+Note that if loadts_ignorerpm is True, this option does nothing.
+Boolean (1, 0, True, False, yes, no) Defaults to False
+
+.IP
+\fBautosavets\fR
+Should yum automatically save a transaction to a file when the transaction is
+solved but not run.
+Boolean (1, 0, True, False, yes, no) Defaults to True
+
+.IP
+\fBfssnap_automatic_pre\fR
+Should yum try to automatically create a snapshot before it runs a transaction.
+Boolean (1, 0, True, False, yes, no) Defaults to False
+
+.IP
+\fBfssnap_automatic_post\fR
+Should yum try to automatically create a snapshot after it runs a transaction.
+Boolean (1, 0, True, False, yes, no) Defaults to False
+
+.IP
+\fBfssnap_automatic_keep\fR
+How many old snapshots should yum keep when trying to automatically create a 
+new snapshot. Setting to 0 disables this feature. Default is '1'.
+
+.IP
+\fBfssnap_percentage\fR
+The size of new snaphosts, expressed as a percentage of the old origin device. 
+Any number between 1 and 100. Default is '100'.
+
+.IP
+\fBfssnap_devices\fR
+The origin LVM devices to use for snapshots. Wildcards and negation are allowed,
+first match (positive or negative) wins.
+Default is: !*/swap !*/lv_swap glob:/etc/yum/fssnap.d/*.conf
+
+.IP
+\fBfssnap_abort_on_errors\fR
+When fssnap_automatic_pre or fssnap_automatic_post is enabled, it's possible to specify which
+fssnap errors should make the transaction fail. The default is `any'.
+
+`broken-setup' - Abort current transaction if snapshot support is unavailable because
+lvm is missing or broken.
+
+`snapshot-failure' - Abort current transaction if creating a snapshot fails (e.g. there is not enough
+free space to make a snapshot).
+
+`any' - Abort current transaction if any of the above occurs.
+
+`none' - Never abort a transaction in case of errors.
+
+.IP
+\fBdepsolve_loop_limit\fR
+Set the number of times any attempt to depsolve before we just give up. This
+shouldn't be needed as yum should always solve or fail, however it has been
+observed that it can loop forever with very large system upgrades. Setting
+this to `0' (or "<forever>") makes yum try forever. Default is `100'.
+
+.IP
+\fBusr_w_check\fR
+Either `0' or `1'. Set this to `0' to disable the checking for writability on
+/usr in the installroot (when going into the depsolving stage). Default is `1'
+(perform the check).
+
+.IP
+\fBskip_missing_names_on_install\fR
+If set to False, 'yum install' will fail if it can't find any of the provided
+names (package, group, rpm file). Boolean (1, 0, True, False, yes, no). Defaults to True.
+
+.IP
+\fBskip_missing_names_on_update\fR
+If set to False, 'yum update' will fail if it can't find any of the provided
+names (package, group, rpm file). It will also fail if the provided name is a package
+which is available, but not installed. Boolean (1, 0, True, False, yes, no). Defaults to True.
+
+.IP
+\fBshell_exit_status\fR
+Determines the exit status that should be returned by `yum shell' when it
+terminates after reading the `exit' command or EOF.
+Possible values are: 0, ?.
+If ? is set, the exit status is that of the last command executed before `exit'
+(bash-like behavior).
+Defaults to 0.
+
+.SH "[repository] OPTIONS"
+.LP 
+The repository section(s) take the following form:
+.IP
+\fBExample\fP:
+[repositoryid] 
+.br 
+name=Some name for this repository
+.br 
+baseurl=url://path/to/repository/ 
+.br 
+
+.IP
+\fBrepositoryid\fR
+Must be a unique name for each repository, one word.
+
+.IP
+\fBname\fR
+A human readable string describing the repository.
+
+.IP
+\fBbaseurl\fR
+Must be a URL to the directory where the yum repository's `repodata' directory
+lives. Can be an http://, ftp:// or file:// URL.
+
+You can specify multiple URLs in one baseurl statement. The best way to do this
+is like this:
+.br
+[repositoryid]
+.br
+name=Some name for this repository
+.br
+baseurl=url://server1/path/to/repository/
+.br
+        url://server2/path/to/repository/
+.br
+        url://server3/path/to/repository/
+.br
+
+The URLs listed are considered different locations (mirrors) of the same
+repository.
+That means, if one URL fails, another one is tried, and so on.
+The order in which the URLs are tried is determined by the \fBfailovermethod\fR
+option.
+
+If you list more than one baseurl= statement in a repository you will find
+yum will ignore the earlier ones and probably act bizarrely. Don't do this,
+you've been warned.
+
+You can use HTTP basic auth by prepending "user:password@" to the server
+name in the baseurl line.  For example: "baseurl=http://user:passwd@example.com/".
+
+.IP
+\fBmetalink\fR
+Specifies a URL to a metalink file for the repomd.xml, a list of mirrors for
+the entire repository are generated by converting the mirrors for the
+repomd.xml file to a baseurl. The metalink file also contains the latest
+timestamp from the data in the repomd.xml, the length of the repomd.xml and
+checksum data. This data is checked against any downloaded repomd.xml file
+and all of the information from the metalink file must match. This can be used
+instead of or with the \fBbaseurl\fR option. Substitution variables, described
+below, can be used with this option. This option disables the mirrorlist option.
+As a special hack is the mirrorlist URL contains the word "metalink" then the
+value of mirrorlist is copied to metalink (if metalink is not set).
+
+.IP
+\fBmirrorlist\fR
+Specifies a URL to a file containing a list of baseurls. This can be used
+instead of or with the \fBbaseurl\fR option. Substitution variables, described
+below, can be used with this option. 
+As a special hack is the mirrorlist URL contains the word "metalink" then the
+value of mirrorlist is copied to metalink (if metalink is not set).
+
+
+.IP
+\fBenabled\fR
+Either `1' or `0'. This tells yum whether or not use this repository.
+
+.IP
+\fBkeepcache\fR
+Overrides the \fBkeepcache\fR option from the [main] section for this repository.
+
+.IP
+\fBgpgcheck\fR
+Either `1' or `0'. This tells yum whether or not it should perform a GPG
+signature check on the packages gotten from this repository.
+
+.IP
+\fBrepo_gpgcheck\fR
+Either `1' or `0'. This tells yum whether or not it should perform a GPG
+signature check on the repodata from this repository.
+
+.IP
+\fBgpgkey\fR
+A URL pointing to the ASCII-armored GPG key file for the repository. This
+option is used if yum needs a public key to verify a package and the required
+key hasn't been imported into the RPM database. If this option is set, yum will
+automatically import the key from the specified URL. You will be prompted before
+the key is installed unless the \fBassumeyes\fR option is set.
+
+Multiple URLs may be specified here in the same manner as the \fBbaseurl\fR
+option (above). If a GPG key is required to install a package from a
+repository, all keys specified for that repository will be installed.
+
+.IP
+\fBgpgcakey\fR
+A URL pointing to the ASCII-armored CA key file for the repository. This is a normal 
+gpg public key - but this key will be used to validate detached signatures of all
+other keys. The idea is you are asked to confirm import for this key. After that any other 
+gpg key needed for package or repository verification, if it has a detached signature which matches this
+key will be automatically imported without user confirmation.
+
+.IP
+\fBexclude\fR
+Same as the [main] \fBexclude\fR option but only for this repository.
+Substitution variables, described below, are honored here.
+
+Can be disabled using --disableexcludes.
+
+.IP
+\fBincludepkgs\fR
+Inverse of exclude, yum will exclude any package in the repo. that doesn't
+match this list. This works in conjunction with exclude and doesn't override it,
+so if you exclude=*.i386 and includepkgs=python* then only packages starting
+with python that do not have an i386 arch. will be seen by yum in this repo.
+
+Substitution variables, described below, are honored here.
+
+Can be disabled using --disableexcludes.
+
+.IP
+\fBenablegroups\fR
+Either `0' or `1'. Determines whether yum will allow the use of package groups
+for this repository. Default is `1' (package groups are allowed).
+
+.IP
+\fBfailovermethod\fR
+Either `roundrobin' or `priority'.
+
+`roundrobin' randomly selects a URL out of
+the list of URLs to start with and proceeds through each of them as it
+encounters a failure contacting the host. 
+
+`priority' starts from the first baseurl listed and reads through them
+sequentially.
+
+\fBfailovermethod\fR defaults to `roundrobin' if not specified.
+
+.IP
+\fBkeepalive\fR
+Either `1' or `0'. This tells yum whether or not HTTP/1.1 keepalive should be
+used with this repository. See the global option in the [main] section above
+for more information.
+
+.IP
+\fBtimeout\fR
+Overrides the \fBtimeout\fR option from the [main] section for this repository.
+
+.IP
+\fBhttp_caching\fR
+Overrides the \fBhttp_caching\fR option from the [main] section for this repository.
+
+.IP
+\fBretries\fR
+Overrides the \fBretries\fR option from the [main] section for this repository.
+
+.IP
+\fBthrottle\fR
+Overrides the \fBthrottle\fR option from the [main] section for this
+repository.
+
+.IP
+\fBbandwidth\fR
+Overrides the \fBbandwidth\fR option from the [main] section for this
+repository.
+
+.IP
+\fBip_resolve \fR
+Overrides the \fBip_resolve\fR option from the [main] section for this
+repository.
+
+.IP
+\fBftp_disable_epsv\fR
+Overrides the \fBftp_disable_epsv\fR option from the [main] section
+for this repository.
+
+.IP
+\fBdeltarpm_percentage\fR
+Overrides the \fBdeltarpm_percentage\fR option from the [main] section
+for this repository.
+
+.IP
+\fBdeltarpm_metadata_percentage\fR
+Overrides the \fBdeltarpm_metadata_percentage\fR option from the [main] section
+for this repository.
+
+.IP
+\fBsslcacert \fR
+Overrides the \fBsslcacert\fR option from the [main] section for this
+repository.
+
+.IP
+\fBsslverify \fR
+Overrides the \fBsslverify\fR option from the [main] section for this
+repository.
+
+.IP
+\fBsslclientcert \fR
+Overrides the \fBsslclientcert\fR option from the [main] section for this
+repository.
+
+.IP
+\fBsslclientkey \fR
+Overrides the \fBsslclientkey\fR option from the [main] section for this
+repository.
+
+.IP
+\fBssl_check_cert_permissions \fR
+Overrides the \fBssl_check_cert_permissions\fR option from the [main] section
+for this repository.
+
+.IP
+\fBmetadata_expire \fR
+Overrides the \fBmetadata_expire\fR option from the [main] section for this
+repository.
+
+.IP
+\fBmetadata_expire_filter \fR
+Overrides the \fBmetadata_expire_filter\fR option from the [main] section for
+this repository.
+
+.IP
+\fBmirrorlist_expire \fR
+Overrides the \fBmirrorlist_expire\fR option from the [main] section for this
+repository.
+
+.IP
+\fBproxy \fR
+URL to the proxy server for this repository. Set to '_none_' to disable the 
+global proxy setting for this repository. If this is unset it 
+inherits it from the global setting
+
+.IP
+\fBproxy_username \fR
+username to use for proxy.
+If this is unset it inherits it from the global setting
+
+.IP
+\fBproxy_password \fR
+password for this proxy.
+If this is unset it inherits it from the global setting
+
+
+.IP
+\fBusername \fR
+username to use for basic authentication to a repo or really any url.
+If this is unset it inherits it from the global setting
+
+.IP
+\fBpassword \fR
+password to use with the username for basic authentication.
+If this is unset it inherits it from the global setting
+
+.IP
+\fBcost \fR
+relative cost of accessing this repository. Useful for weighing one repo's packages
+as greater/less than any other. defaults to 1000
+
+.IP
+\fBskip_if_unavailable \fR
+If set to True yum will continue running if this repository cannot be 
+contacted for any reason. This should be set carefully as all repos are consulted
+for any given command. Defaults to False.
+
+.IP
+\fBasync \fR
+If set to True Yum will download packages and metadata from this repo in
+parallel, if possible.  Defaults to True.
+
+.IP
+\fBui_repoid_vars \fR
+Overrides the \fBui_repoid_vars\fR option from the [main] section for this
+repository.
+
+.IP
+\fBcompare_providers_priority \fR
+During depsolving, when choosing the best provider among several, yum will respect
+the priority of each provider's repository (note that there are other factors
+which yum considers, which may overweigh the repository priority). The value is
+an integer from 1 to 99, 1 being the most preferred repository, and 99 being
+the least preferred one. By default all repositories have the priority of 80.
+
+.SH "URL INCLUDE SYNTAX"
+.LP
+The inclusion of external configuration files is supported for /etc/yum/yum.conf
+and the .repo files in the /etc/yum/repos.d directory. To include a URL, use a
+line of the following format:
+
+include=url://to/some/location
+
+The configuration file will be inserted at the position of the "include=" line.
+Included files may contain further include lines. Yum will abort with an error
+if an inclusion loop is detected.
+
+.SH "GLOB: FOR LIST OPTIONS"
+.LP
+Any of the configurations options which are a list of items can be specfied
+using the glob syntax: \fBglob:/etc/path/somewhere.d/*.conf\fR. This
+will read in all files matching that glob and include all lines in each file
+(excluding comments and blank lines) as items in the list.
+.LP
+
+.SH "VARIABLES"
+.LP
+There are a number of variables you can use to ease maintenance of yum's
+configuration files. They are available in the values of several options
+including \fBname\fR, \fBbaseurl\fR and \fBcommands\fB.
+.LP
+
+.IP
+\fB$releasever\fR
+This will be replaced with the value of the version of the package listed
+in \fBdistroverpkg\fR. This defaults to the version of `redhat-release'
+package.
+
+.IP
+\fB$arch\fR
+This will be replaced with the architecture or your system
+as detected by yum.
+
+.IP
+\fB$basearch\fR
+This will be replaced with your base architecture in yum. For example, if
+your $arch is i686 your $basearch will be i386.
+
+.IP
+\fB$uuid\fR
+This will be replaced with a unique but persistent uuid for this machine. 
+The value that is first generated will be stored in /var/lib/yum/uuid and
+reused until this file is deleted.
+
+.IP
+\fB$YUM0-$YUM9\fR
+These will be replaced with the value of the shell environment variable of
+the same name. If the shell environment variable does not exist then the
+configuration file variable will not be replaced.
+
+.LP
+When variable names are parsed in a string, all alphanumeric characters and
+underscores immediately following a $ sign are interpreted as part of a name.
+If a variable is undefined, it will not be replaced.
+For example, the strings $releasever-foo or $releasever/foo will be expanded
+with the $releasever value accordingly, whereas $releaseverfoo or
+$releasever_foo will not be expanded.
+
+As of 3.2.28, any properly named file in /etc/yum/vars is turned into
+a variable named after the filename (or overrides any of the above variables).
+Filenames may contain only alphanumeric characters and underscores
+and be in lowercase.
+
+Note that no warnings/errors are given if the files are unreadable, so creating
+files that only root can read may be confusing for users.
+
+Also note that only the first line will be read and all new line 
+characters are removed, as a convenience. However, no other checking is 
+performed on the data. This means it is possible to have bad character 
+data in any value.
+
+.SH "FILES"
+.nf
+/etc/yum/yum.conf
+/etc/yum/repos.d/
+/etc/yum/pluginconf.d/
+/etc/yum/protected.d
+/etc/yum/vars
+
+.SH "SEE ALSO"
+.LP 
+yum(8)
+

--- a/man8/yum-cron.8
+++ b/man8/yum-cron.8
@@ -1,0 +1,51 @@
+.\" yum-cron - cron interface for yum
+.TH "yum-cron" "8" ""  "Nick Jacek" ""
+.SH "NAME"
+yum-cron \- an interface to conveniently call yum from cron
+
+.SH "SYNOPSIS"
+\fByum-cron\fP [config-file]
+
+.SH "DESCRIPTION"
+.PP 
+\fByum-cron\fP is an alternate interface to yum that is optimised to
+be convenient to call from cron.  It provides methods to keep
+repository metadata up to date, and to check for, download, and apply
+updates.  Rather than accepting many different command line arguments,
+the different functions of yum-cron can be accessed through config
+files.
+.PP 
+\fIconfig-file\fP is used to optionally specify the path to the
+configuration file to use.  If it is not given, the default
+configuration file will be used.  It is useful to be able to specify
+different configuration files for different use cases.  For example,
+one configuration file might be set to update the repository metadata,
+and a line could be added to the crontab to run yum-cron frequently
+using this file.  Then, another configuration file might be set to
+install updates, and yum-cron could be run from cron using this file
+just once each day.
+
+.SH "FILES"
+.nf
+/etc/yum/yum-cron.conf
+/etc/yum/yum-cron-hourly.conf
+/etc/yum/yum-cron-security.conf
+.fi 
+
+.PP
+.SH "SEE ALSO"
+.nf
+.I yum (8)
+.fi
+
+.PP
+.SH "AUTHORS"
+.nf
+See the Authors file included with this program.
+.fi
+
+.PP
+.SH "BUGS"
+There of course aren't any bugs, but if you find any, you should email
+ the mailing list, yum@lists.baseurl.org, or consult bugzilla.
+.fi

--- a/man8/yum-updatesd.8
+++ b/man8/yum-updatesd.8
@@ -1,0 +1,18 @@
+.TH "yum-updatesd" "8" "" "Jeremy Katz" ""
+.SH "NAME"
+yum-updatesd \- Update notifier daemon
+.SH "SYNOPSIS"
+\fByum-updatesd\fP
+.SH "DESCRIPTION"
+.PP 
+\fByum-updatesd\fP provides notification of updates which are
+available to be applied to your system.  This notification can be done
+either via syslog, email or over dbus.  Configuration is done via the
+\fByum-updatesd.conf(5) \fR file.  
+.PP 
+.SH "SEE ALSO"
+.nf
+.I yum(8)
+.I yum-updatesd.conf(5)
+http://yum.baseurl.org/
+.fi 

--- a/man8/yum.8
+++ b/man8/yum.8
@@ -1,0 +1,1216 @@
+.\" yum - Yellowdog Updater Modified
+.TH "yum" "8" ""  "Seth Vidal" ""
+.SH "NAME"
+yum \- Yellowdog Updater Modified
+.SH "SYNOPSIS"
+\fByum\fP [options] COMMAND [package ...]
+.SH "DESCRIPTION"
+.PP 
+\fByum\fP is an interactive, rpm based, package manager. It can automatically
+perform system updates, including dependency analysis and obsolete processing
+based on "repository" metadata. It can also perform installation of new
+packages, removal of old packages and perform queries on the installed and/or
+available packages among many other commands/services (see below)\&. \fByum\fP
+is similar to other high level package managers like apt\-get and smart\&.
+.PP
+While there are some graphical interfaces directly to the \fByum\fP code, more
+recent graphical interface development is happening with PackageKit and the
+gnome\-packagekit application\&.
+.PP 
+\fIcommand\fP is one of:
+.br 
+.I \fR * install package1 [package2] [\&.\&.\&.]
+.br 
+.I \fR * update [package1] [package2] [\&.\&.\&.]
+.br 
+.I \fR * update-to [package1] [package2] [\&.\&.\&.]
+.br 
+.I \fR * update-minimal [package1] [package2] [\&.\&.\&.]
+.br 
+.I \fR * check\-update
+.br 
+.I \fR * upgrade [package1] [package2] [\&.\&.\&.] 
+.br
+.I \fR * upgrade-to [package1] [package2] [\&.\&.\&.] 
+.br
+.I \fR * distribution-synchronization [package1] [package2] [\&.\&.\&.] 
+.br
+.I \fR * remove | erase package1 [package2] [\&.\&.\&.]
+.br 
+.I \fR * autoremove [package1] [\&.\&.\&.]
+.br 
+.I \fR * list [\&.\&.\&.]
+.br 
+.I \fR * info [\&.\&.\&.]
+.br 
+.I \fR * provides  | whatprovides feature1 [feature2] [\&.\&.\&.]
+.br  
+.I \fR * clean [ packages | metadata | expire-cache | rpmdb | plugins | all ]
+.br
+.I \fR * makecache [fast]
+.br
+.I \fR * groups  [\&.\&.\&.]
+.br
+.I \fR * search string1 [string2] [\&.\&.\&.]
+.br
+.I \fR * shell [filename]
+.br
+.I \fR * resolvedep dep1 [dep2] [\&.\&.\&.] 
+    (maintained for legacy reasons only - use repoquery or yum provides)
+.br
+.I \fR * localinstall rpmfile1 [rpmfile2] [\&.\&.\&.] 
+    (maintained for legacy reasons only - use install)
+.br
+.I \fR * localupdate rpmfile1 [rpmfile2] [\&.\&.\&.]
+    (maintained for legacy reasons only - use update)
+.br
+.I \fR * reinstall package1 [package2] [\&.\&.\&.] 
+.br
+.I \fR * downgrade package1 [package2] [\&.\&.\&.] 
+.br
+.I \fR * deplist package1 [package2] [\&.\&.\&.] 
+.br
+.I \fR * repolist [all|enabled|disabled] 
+.br
+.I \fR * repoinfo [all|enabled|disabled] 
+.br
+.I \fR * repository-packages <enabled-repoid> <install|remove|remove-or-reinstall|remove-or-distribution-synchronization> [package2] [\&.\&.\&.]
+.br
+.I \fR * version [ all | installed | available | group-* | nogroups* | grouplist | groupinfo ]
+.br
+.I \fR * history [info|list|packages-list|packages-info|summary|addon-info|redo|undo|rollback|new|sync|stats] 
+.br
+.I \fR * load-transaction [txfile]
+.br
+.I \fR * updateinfo [summary | list | info | remove-pkgs-ts | exclude-updates | exclude-all | check-running-kernel]
+.br
+.I \fR * fssnapshot [summary | list | have-space | create | delete]
+.br
+.I \fR * fs [filters | refilter | refilter-cleanup | du]
+.br
+.I \fR * check
+.br 
+.I \fR * help [command] 
+.br
+.PP 
+Unless the \-\-help or \-h option is given, one of the above commands
+must be present\&.
+.PP
+Repository configuration is honored in all operations.
+.PP 
+.IP "\fBinstall\fP"
+Is used to install the latest version of a package or
+group of packages while ensuring that all dependencies are
+satisfied\&.  (See \fBSpecifying package names\fP for more information) 
+If no package matches the given package name(s), they are assumed to be a shell 
+glob and any matches are then installed\&. If the name starts with @^ then it
+is treated as an environment group (group install @^foo), an @ character and
+it's treated as a group (plain group install)\&.
+
+If the name starts with a "-" character, then a search is done within the
+transaction and any matches are removed. Note that Yum options use the same
+syntax and it may be necessary to use "--" to resolve any possible conflicts.
+
+If the name is a file, then install works
+like localinstall\&. If the name doesn't match a package, then package
+"provides" are searched (e.g. "_sqlitecache.so()(64bit)") as are
+filelists (Eg. "/usr/bin/yum"). Also note that for filelists, wildcards will
+match multiple packages\&.
+
+Because install does a lot of work to make it as easy as possible to use, there
+are also a few specific install commands "\fBinstall-n\fP", "\fBinstall-na\fP"
+and "\fBinstall-nevra\fP". These only work on package names, and do not process
+wildcards etc.
+.IP 
+.IP "\fBupdate\fP"
+If run without any packages, update will update every currently
+installed package.  If one or more packages or package globs are specified, Yum will
+only update the listed packages\&.  While updating packages, \fByum\fP
+will ensure that all dependencies are satisfied\&. (See \fBSpecifying package names\fP for more information) 
+If the packages or globs specified match to packages which are not currently installed then update will
+not install them\&. update operates on groups, files, provides and filelists
+just like the "install" command\&.
+
+If the main obsoletes configure option is true (default) or the \-\-obsoletes
+flag is present \fByum\fP will include package 
+obsoletes in its calculations - this makes it better for distro\-version 
+changes, for example: upgrading from somelinux 8.0 to somelinux 9.
+
+Note that "\fBupdate\fP" works on installed packages first, and only if there
+are no matches does it look for available packages. The difference is most
+noticeable when you do "\fBupdate\fP foo-1-2" which will act exactly as
+"\fBupdate\fP foo" if foo-1-2 is installed. You can use the "\fBupdate-to\fP"
+if you'd prefer that nothing happen in the above case.
+.IP 
+.IP "\fBupdate-to\fP"
+This command works like "\fBupdate\fP" but always specifies the version of the
+package we want to update to.
+.IP 
+.IP "\fBupdate-minimal\fP"
+This works like the update command, but if you have the package foo-1
+installed and have foo-2 (bugfix) and foo-3 (enhancement) available with
+updateinfo.xml then update-minimal --bugfix will update you to foo-2.
+.IP 
+.IP "\fBcheck\-update\fP"
+Implemented so you could know if your machine had any updates that needed to
+be applied without running it interactively. Returns exit value of 100 if
+there are packages available for an update. Also returns a list of the packages
+to be updated in list format. Returns 0 if no packages are available for
+update. Returns 1 if an error occurred.
+Running in verbose mode also shows obsoletes.
+.IP
+.IP "\fBupgrade\fP"
+Is the same as the update command with the \-\-obsoletes flag set. See update 
+for more details.
+.IP 
+.IP "\fBupgrade-to\fP"
+This command works like "\fBupgrade\fP" but always specifies the version of the
+package we want to update to.
+.IP 
+.IP "\fBdistribution\-synchronization\fP or \fBdistro\-sync\fP"
+Synchronizes the installed package set with the latest packages available, this
+is done by either obsoleting, upgrading or downgrading as appropriate. This will
+"normally" do the same thing as the upgrade command however if you have the
+package FOO installed at version 4, and the latest available is only
+version 3, then this command will \fBdowngrade\fP FOO to version 3.
+
+If you give the optional argument "full", then the command will also reinstall
+packages where the install checksum and the available checksum do not match. And
+remove old packages (can be used to sync. rpmdb versions). The optional argument
+"different" can be used to specify the default operation.
+
+This command does not perform operations on groups, local packages or negative
+selections.
+.IP 
+.IP "\fBremove\fP or \fBerase\fP"
+Are used to remove the specified packages from the system
+as well as removing any packages which depend on the package being
+removed\&. remove operates on groups, files, provides and filelists just like
+the "install" command\&.(See \fBSpecifying package names\fP for more information) 
+
+Note that "yum" is included in the protected_packages configuration, by default.
+So you can't accidentally remove yum itself.
+
+The remove_leaf_only configuration changes the behaviour of this command
+to only remove packages which aren't required by something else.
+
+The clean_requirements_on_remove configuration changes the behaviour of this
+command to also remove packages that are only dependencies of this package.
+
+Because remove does a lot of work to make it as easy as possible to use, there
+are also a few specific remove commands "\fBremove-n\fP", "\fBremove-na\fP"
+and "\fBremove-nevra\fP". These only work on package names, and do not process
+wildcards etc.
+.IP 
+.IP "\fBautoremove\fP"
+.IP 
+With one or more arguments this command works like running the "\fBremove\fP"
+command with the clean_requirements_on_remove turned on. However you can also
+specify no arguments, at which point it tries to remove any packages that
+weren't installed explicitly by the user and which aren't required by
+anything (so called leaf packages).
+
+Because autoremove does a lot of work to make it as easy as possible to use,
+there are also a few specific autoremove commands "\fBautoremove-n\fP", 
+"\fBautoremove-na\fP" and "\fBautoremove-nevra\fP". These only work on package
+names, and do not process wildcards etc.
+.IP "\fBlist\fP"
+Is used to list various information about available
+packages; more complete details are available in the \fIList Options\fP
+section below\&.
+.IP 
+.IP "\fBprovides\fP or \fBwhatprovides\fP"
+Is used to find out which package provides some feature
+or file. Just use a specific name or a file-glob-syntax wildcards to list
+the packages available or installed that provide that feature or file\&.
+.IP 
+.IP "\fBsearch\fP"
+This is used to find packages when you know something about the package but
+aren't sure of it's name. By default search will try searching just package
+names and summaries, but if that "fails" it will then try descriptions and url.
+
+Yum search orders the results so that those packages matching more terms will
+appear first.
+
+You can force searching everything by specifying "all" as the first argument.
+.IP 
+.IP "\fBinfo\fP"
+Is used to list a description and summary information about available
+packages; takes the same arguments as in the \fIList Options\fP
+section below\&.
+.IP 
+.IP "\fBclean\fP"
+Is used to clean up various things which accumulate in the
+\fByum\fP cache directory over time.  More complete details can be found in
+the \fIClean Options\fP section below\&.
+.IP 
+.IP "\fBmakecache\fP"
+Is used to download and make usable all the metadata for the currently enabled
+\fByum\fP repos. If the argument "fast" is passed, then we just try to make
+sure the repos are current (much like "yum clean expire-cache").
+.IP 
+.IP "\fBgroups\fP"
+A command, new in 3.4.2, that collects all the subcommands that act on groups
+together. Note that recent yum using distributions (Fedora-19+, RHEL-7+) have
+configured group_command=objects which changes how group commands act in some
+important ways.
+
+"\fBgroup install\fP" is used to install all of the individual packages in a
+group, of the specified types (this works as if you'd taken each of those
+package names and put them on the command line for a "yum install" command).
+ The group_package_types configuration option specifies which types will
+be installed.
+ If you wish to "reinstall" a group so that you get a package that is currently
+blacklisted the easiest way to do that currently is to install the package
+manually and then run "groups mark packages-sync mygroup mypackagename" (or
+use yumdb to set the group_member of the package(s)).
+
+"\fBgroup update\fP" is just an alias for group install, when using
+group_command=compat. This will install packages in the group not already
+installed and upgrade existing packages. With group_command=simple it will just
+upgrade already installed packages. With group_command=objects it will try to
+upgrade the group object, installing any available packages not blacklisted
+(marked '-' in group info) and will upgrade the installed packages.
+
+"\fBgroup list\fP" is used to list the available groups from all \fByum\fP
+repos. When group_command=objects the group is installed if the user
+explicitly installed it (or used the group mark* commands to mark it installed).
+It does not need to have any packages installed.
+When not using group_command=objects groups are shown as "installed" if all
+mandatory packages are installed, or if a group doesn't
+have any mandatory packages then it is installed if any of the optional or
+default package are installed (when not in group_command=objects mode).
+You can pass optional arguments to the list/summary commands: installed,
+available, environment, language, packages, hidden and ids (or any of those
+prefixed by "no" to turn them off again).
+Note that groups that are available but hidden will not be listed unless
+\'hidden\' keyword is passed to the command.
+If you pass the \-v option, to enable verbose mode, then the groupids are
+displayed by default (but "yum group list ids" is often easier to read).
+
+"\fBgroup remove\fP" is used to remove all of the packages in a group, unlike "groupinstall" this
+will remove everything regardless of group_package_types. It is worth pointing
+out that packages can be in more than one group, so "group install X Y" followed
+by "group remove Y" does not do give you the same result as "group install X".
+
+The groupremove_leaf_only configuration changes the behaviour of this command
+to only remove packages which aren't required by something else.
+
+"\fBgroup info\fP" is used to give the description and package list of a group (and which type
+those packages are marked as). Note that you can use the yum-filter-data and
+yum-list-data plugins to get/use the data the other way around (i.e. what
+groups own packages need updating). If you pass the \-v option, to enable verbose
+mode, then the package names are matched against installed/available packages
+similar to the list command.
+
+When using group_command=objects, the info command will display markers next
+to each package saying how that package relates to the group object. The
+meaning of these markers is:
+
+.br
+"-" = Package isn't installed, and won't be installed as part of the group (Eg.  "yum group install foo -pkgA" or "yum group install foo; yum remove pkgA" … this will have pkgA marked as '-')
+.br
+"+" = Package isn't installed, but will be the next time you run "yum upgrade" or "yum group upgrade foo"
+.br
+" " = Package is installed, but wasn't installed via the group (so "group remove foo" won't remove it).
+.br
+"=" = Package is installed, and was installed via the group.
+
+you can move an installed package into an installed group using either
+"group mark package-sync/package-sync-forced" or "yumdb set group_member".
+
+"\fBgroup summary\fP" is used to give a quick summary of how many groups
+are installed and available.
+
+"\fBgroup mark\fP" and "\fBgroup unmark\fP" are used when groups are configured
+in group_command=objects mode. These commands then allow you to alter yum's idea
+of which groups are installed, and the packages that belong to them.
+
+"\fBgroup mark install\fP" mark the group as installed. When
+installed "\fByum upgrade\fP" and "\fByum group upgrade\fP" will install new
+packages for the group (only those packages already installed will be marked as
+members of the installed group to start with).
+
+"\fBgroup mark remove\fP" the opposite of mark install.
+
+"\fBgroup mark packages\fP" takes a group id (which must be installed) and marks
+any given installed packages (which aren't members of a group) as members of
+the group. Note that the data from the repositories does not need to specify
+the packages as a member of the group.
+
+"\fBgroup mark packages-force\fP" works like mark packages, but doesn't care if
+the packages are already members of another group.
+
+"\fBgroup mark blacklist\fP" will blacklist all packages marked to be installed
+for a group. After this command a "yum group upgrade" will not install any new
+packages as part of the group.
+
+"\fBgroup mark convert-blacklist\fP"
+
+"\fBgroup mark convert-whitelist\fP"
+
+"\fBgroup mark convert\fP" converts the automatic data you get
+without using groups as objects into groups as objects data, in other words
+this will make "yum --setopt=group_command=objects groups list" look as similar
+as possible to the current output of
+"yum --setopt=group_command=simple groups list". This makes it much
+easier to convert to groups as objects without having to reinstall. For groups
+that are installed the whitelist variant will mark all uninstalled packages for
+the group as to be installed on the next "yum group upgrade", the blacklist
+variant (current default) will mark them all as blacklisted.
+
+"\fBgroup unmark packages\fP" remove a package as a member from any groups.
+.IP
+.IP "\fBshell\fP"
+Is used to enter the 'yum shell', when a filename is specified the contents of
+that file is executed in yum shell mode. See \fIyum-shell(8)\fP for more info.
+.IP
+.IP "\fBresolvedep\fP"
+Is used to list packages providing the specified dependencies, at most one
+package is listed per dependency. This command is maintained for legacy
+reasons only, use repoquery instead.
+.IP
+.IP "\fBlocalinstall\fP"
+Is used to install a set of local rpm files. If required the enabled 
+repositories will be used to resolve dependencies. Note that the install command
+will do a local install, if given a filename. This command is maintained for legacy
+reasons only.
+.IP
+.IP "\fBlocalupdate\fP"
+Is used to update the system by specifying local rpm files. Only the specified 
+rpm files of which an older version is already installed will be installed,
+the remaining specified packages will be ignored.
+If required the enabled repositories will be used to resolve dependencies. Note
+that the update command will do a local update, if given a filename. This command is maintained for
+legacy reasons only.
+.IP
+.IP "\fBreinstall\fP"
+Will reinstall the identically versioned package as is currently installed. 
+This does not work for "installonly" packages, like Kernels. reinstall operates
+on groups, files, provides and filelists just like the "install" command\&.
+.IP
+.IP "\fBdowngrade\fP"
+Will try and downgrade a package from the version currently installed to the
+previously highest version (or the specified version).
+The depsolver will not necessarily work, but if you specify all the packages it
+should work (thus, all the simple cases will work). Also this does not
+work for "installonly" packages, like Kernels. downgrade operates
+on groups, files, provides, filelists and rpm files just like the "install" command\&.
+.IP
+.IP "\fBswap\fP"
+At it's simplest this is just a simpler way to remove one set of package(s) and
+install another set of package(s) without having to use the "shell" command.
+However you can specify different commands to call than just remove or install,
+and you can list multiple packages (it splits using the "--" marker).
+Note that option parsing will remove the first "--" in an argument list on the
+command line.
+
+
+Examples:
+
+.nf
+swap foo bar
+swap -- remove foo -- install bar
+swap foo group install bar-grp
+swap -- group remove foo-grp -- group install bar-grp
+.fi
+.IP
+.IP "\fBdeplist\fP"
+Produces a list of all dependencies and what packages provide those
+dependencies for the given packages. As of 3.2.30 it now just shows the latest
+version of each package that matches (this can be changed by
+using --showduplicates) and it only shows the newest providers (which can be
+changed by using --verbose).
+.IP
+.IP "\fBrepolist\fP"
+Produces a list of configured repositories. The default is to list all
+enabled repositories. If you pass \-v, for verbose mode, or use repoinfo then
+more information is listed. If the first argument is \'enabled\', \'disabled\'
+or \'all\' then the command will list those types of repos.
+
+You can pass repo id or name arguments, or wildcards which to match against
+both of those. However if the id or name matches exactly then the repo will
+be listed even if you are listing enabled repos and it is disabled.
+
+In non-verbose mode the first column will start with a \'*\' if the repo. has
+metalink data and the latest metadata is not local and will start with a
+\'!\' if the repo. has metadata that is expired (this can happen due to
+metadata_expire_filter). For non-verbose mode the
+last column will also display the number of packages in the repo. and (if there
+are any user specified excludes) the number of packages excluded.
+
+One last special feature of repolist, is that if you are in non-verbose mode
+then yum will ignore any repo errors and output the information it can get
+(Eg. "yum clean all; yum -C repolist" will output something, although the
+package counts/etc. will be zeroed out).
+.IP
+.IP "\fBrepoinfo\fP"
+.IP
+This command works exactly like repolist -v.
+.IP
+.IP "\fBrepository\-packages\fP"
+Treat a repo. as a collection of packages (like "yum groups") allowing the user
+to install or remove them as a single entity.
+
+"repository\-packages <repo> list" - Works like the "yum list" command, but
+only shows packages from the given repository.
+
+"repository\-packages <repo> info" - Works like the "yum info" command, but
+only shows packages from the given repository.
+
+"repository\-packages <repo> check-update" - Works like the
+"yum check-update" command, but only shows packages from the given repository.
+
+"repository\-packages <repo> install" - Install all of the packages in the
+repository, basically the same as: yum install $(repoquery --repoid=<repo> -a).
+Specific packages/wildcards can be specified.
+
+"repository\-packages <repo> upgrade" - Update all of the packages in the
+repository, basically the same as: yum upgrade $(repoquery --repoid=<repo> -a).
+Specific packages/wildcards can be specified.
+
+"repository\-packages <repo> upgrade-to" - Update all of the packages in the
+repository, basically the same as: yum upgrade $(repoquery --repoid=<repo> -a).
+Without arguments it works the same as upgrade, with arguments it just
+interprets them as the versions you want to move to.
+
+"repository\-packages <repo> reinstall-old" - ReInstall all of the packages 
+that are installed from the repository and available in the
+repository, similar to: yum reinstall $(yumdb search-quiet from_repo <repo>).
+
+"repository\-packages <repo> move-to" - ReInstall all of the packages 
+that are available in the repository, basically the same as:
+yum reinstall $(repoquery --repoid=<repo> -a).
+
+"repository\-packages <repo> reinstall" - Tries to do reinstall-old, but if that
+produces no packages then tries move-to.
+
+"repo\-pkgs <repo> remove" - Remove all of the packages in the repository, very
+similar to: yum remove $(repoquery --repoid=<repo> -a). However the
+repopkgsremove_leaf_only option is obeyed.
+
+"repo\-pkgs <repo> remove-or-reinstall" - Works like remove for any package
+that doesn't have the exact same version in another repository. For any package
+that does have the exact NEVRA in another repository then that version will be
+reinstalled.
+
+"repo\-pkgs <repo> remove-or-distro-sync" - Works like remove for any package
+that doesn't exist in another repository. For any package that does exist
+it tries to work as if distro-sync was called (with the repo. disabled).
+
+.IP
+.IP "\fBversion\fP"
+Produces a "version" of the rpmdb, and of the enabled repositories if "all" is
+given as the first argument. You can also specify version groups in the
+version-groups configuration file. If you pass \-v, for verbose mode, more
+information is listed. The version is calculated by taking an SHA1 hash of the
+packages (in sorted order), and the checksum_type/checksum_data entries from
+the yumdb. Note that this rpmdb version is now also used significantly within
+yum (esp. in yum history).
+
+The version command will now show "groups" of packages as a separate version,
+and so takes sub-commands:
+
+"version grouplist" - List the defined version groups.
+
+"version groupinfo" - Get the complete list of packages within one or more version groups.
+
+"version installed" - This is the default, only show the version information for installed packages.
+
+"version available" - Only show the version information for available packages.
+
+"version all" - Show the version information for installed and available packages.
+
+"version nogroups | nogroups-*" - Just show the main version information.
+
+"version group-*" - Just show the grouped version information, if more arguments are given then only show the data for those groups.
+
+.IP
+.IP "\fBhistory\fP"
+The history command allows the user to view what has happened in past
+transactions (assuming the history_record config. option is set). You can use
+info/list/packages-list/packages-info/summary to view what happened,
+undo/redo/rollback to act on that information and new to start a new history
+file.
+
+The info/list/summary commands take either a transaction id or a package (with
+wildcards, as in \fBSpecifying package names\fP), all three can also be passed
+no arguments. list can be passed the keyword "all" to list all the transactions.
+
+The info command can also take ranges of transaction ids, of the form start..end,
+which will then display a merged history as if all the transactions in the range
+had happened at once\&.
+.br
+Eg. "history info 1..4" will merge the first four transactions and display them
+as a single transaction.
+
+The packages-list/packages-info commands takes a package  (with wildcards, as in
+\fBSpecifying package names\fP). And show data from the point of view of that
+package.
+
+The undo/redo/rollback commands take either a single transaction id or the
+keyword last and an offset from the last transaction (Eg. if you've done 250
+transactions, "last" refers to transaction 250, and "last-4" refers to
+transaction 246).
+The redo command can also take some optional arguments before you specify the
+transaction. "force-reinstall" tells it reinstall any packages that were
+installed in that transaction (via install, upgrade or downgrade).
+"force-remove" tells it to forcibly remove any packages that were updated or
+downgraded.
+
+The undo/redo commands act on the specified transaction, undo'ing or repeating
+the work of that transaction. While the rollback command will undo all
+transactions up to the point of the specified transaction. For example, if you
+have 3 transactions, where package A; B and C where installed respectively.
+Then "undo 1" will try to remove package A, "redo 1" will try to install package
+A (if it is not still installed), and "rollback 1" will try to remove packages
+B and C. Note that after a "rollback 1" you will have a fourth transaction,
+although the ending rpmdb version (see: yum version) should be the same in
+transactions 1 and 4.
+
+The addon-info command takes a transaction ID, and the packages-list command
+takes a package (with wildcards).
+
+The stats command shows some statistics about the current history DB.
+
+The sync commands allows you to change the rpmdb/yumdb data stored for any
+installed packages, to whatever is in the current rpmdb/yumdb (this is mostly
+useful when this data was not stored when the package went into the history DB).
+
+In "history list" you can change the behaviour of the 2nd column via the
+configuration option history_list_view.
+
+In "history list" output the Altered column also gives some extra information
+if there was something not good with the transaction (this is also shown at the
+end of the package column in the packages-list command).
+
+.br
+.I \fB>\fR - The rpmdb was changed, outside yum, after the transaction.
+.br
+.I \fB<\fR - The rpmdb was changed, outside yum, before the transaction.
+.br
+.I \fB*\fR - The transaction aborted before completion.
+.br
+.I \fB#\fR - The transaction completed, but with a non-zero status.
+.br
+.I \fBE\fR - The transaction completed fine, but had warning/error output during the transaction.
+.br
+.I \fBP\fR - The transaction completed fine, but problems already existed in the rpmdb.
+.br
+.I \fBs\fR - The transaction completed fine, but --skip-broken was enabled and had to skip some packages.
+.br
+
+
+.IP
+.IP "\fBload-transaction\fP"
+This command will re-load a saved yum transaction file, this allows you to
+run a transaction on one machine and then use it on another.
+The two common ways to get a saved yum transaction file are from
+"yum -q history addon-info last saved_tx" or via the automatic saves in
+$TMPDIR/yum_save_tx.* when a transaction is solved but not run.
+
+Running the command without an argument, or a directory as an argument will
+try and list the possible files available to load. Showing if the packages are
+still available, if the rpmdb matches the current rpmdb, how many transaction
+install/removes members are in the saved transaction and what the filename is.
+
+.IP
+.IP "\fBupdateinfo\fP"
+This command has a bunch of sub-commands to act on the updateinfo in the
+repositories. The simplest commands are:
+
+.br
+.I \fR yum updateinfo info [all | available | installed | updates]
+.br 
+.I \fR yum updateinfo list [all | available | installed | updates]
+.br 
+.I \fR yum updateinfo [summary] [all | available | installed | updates]
+.br 
+
+which all display information about the available update information relevant
+to your machine (including anything installed, if you supply "all").
+.br
+
+.br
+.I \fR "\fB* updates\fP"
+Is used to display information about advisories for packages that can be
+updated. This is the default.
+.br
+.I \fR "\fB* installed\fP"
+Is used to display information only about installed advisories.
+.br
+.I \fR "\fB* available\fP"
+Is used to display information about advisories for packages available
+for updating or installation.
+.br
+.I \fR "\fB* all\fP"
+Is used to display information about both installed and available advisories.
+
+.br
+They all take as arguments:
+
+.br
+.br
+.I \fR "\fB* <advisory> [advisory...]\fP"
+Is used to display information about one or more advisories.
+
+.br
+.I \fR "\fB* <package> [package...]\fP"
+Is used to display information about one or more packages.
+
+.br
+.I \fR "\fB* bugzillas / bzs\fP"
+Is the subset of the updateinfo information, pertaining to the bugzillas.
+
+.br
+.I \fR "\fB* cves\fP"
+Is the subset of the updateinfo information, pertaining to the CVEs.
+
+.br
+.I \fR "\fB* enhancement\fP"
+Is the subset of the updateinfo information, pertaining to enhancements.
+
+.br
+.I \fR "\fB* bugfix\fP"
+Is the subset of the updateinfo information, pertaining to bugfixes.
+
+.br
+.I \fR "\fB* security / sec\fP"
+Is the subset of the updateinfo information, pertaining to security.
+
+.br
+.I \fR "\fB* severity / sev\fP"
+Include security relevant packages of this severity.
+
+.br
+.I \fR "\fB* recommended\fP"
+Is the subset of the updateinfo information, pertaining to recommended updates.
+
+.br
+.I \fR "\fB* new-packages\fP"
+Is the subset of the updateinfo information, pertaining to new packages. These
+are packages which weren't available at the initial release of your
+distribution.
+.br
+
+There are also three sub-commands to remove packages when using "yum shell", 
+they are:
+
+.br
+.I \fR yum updateinfo remove-pkgs-ts
+
+.br 
+.I \fR yum updateinfo exclude-updates
+
+.br 
+.I \fR yum updateinfo exclude-all
+.br 
+
+they all take the following arguments:
+
+.br
+.I \fR* [bzs=foo] [advisories=foo] [cves=foo] [security-severity=foo] [security] [bugfix]
+.br 
+
+and finally there is a command to manually check the running kernel against
+updateinfo data:
+
+.br
+.I \fR yum updateinfo check-running-kernel
+.br 
+
+.IP
+.IP "\fBfssnapshot\fP or \fBfssnap\fP"
+This command has a few sub-commands to act on the LVM data of the host, to list
+snapshots and to create and remove them. The simplest commands, to display
+information about the configured LVM snapshotable devices, are:
+
+.br 
+.I \fR yum fssnapshot [summary]
+.br 
+.I \fR yum fssnapshot list
+.br
+.I \fR yum fssnapshot have-space
+.br
+
+then you can create and delete snapshots using:
+
+.br
+.I \fR yum fssnapshot create
+.br 
+.I \fR yum fssnapshot delete <device(s)>
+.br 
+
+.br
+Configuration Options: \fBfssnap_automatic_pre\fP, \fBfssnap_automatic_post\fP, \fBfssnap_automatic_keep\fP, \fBfssnap_percentage\fP, \fBfssnap_devices\fP, \fBfssnap_abort_on_errors\fP
+
+.IP
+.IP "\fBfs\fP"
+This command has a few sub-commands to act on the filesystem data of the host,
+mainly for removing languages/documentation for minimal installs:
+
+.br 
+.I \fR yum fs filters
+
+.br 
+.I \fR yum fs filter languages en:es
+
+.br 
+.I \fR yum fs filter documentation
+
+.br 
+.I \fR yum fs refilter [package(s)]
+
+.br 
+.I \fR yum fs refilter-cleanup [package(s)]
+
+.br 
+.I \fR yum fs du [path]
+
+.br 
+.I \fR yum fs status [path]
+
+.br 
+.I \fR yum fs diff [path]
+
+
+the first 3 being a simple interface to change yum.conf altering the tsflags
+and override_install_langs configurations. The refilter command is an optimized
+way of calling "yum reinstall" to reinstall the packages with the new filters
+applied. The refilter-cleanup command is needed because rpm doesn't actually
+remove the files on reinstall, as it should. And the du/status/diff commands are
+included so you can easily see the space used/saved and any other changes.
+
+.IP
+.IP "\fBcheck\fP"
+Checks the local rpmdb and produces information on any problems it finds. You
+can pass the check command the arguments "dependencies", "duplicates", "obsoleted" or "provides",
+to limit the checking that is performed (the default is "all" which does all).
+
+.IP
+.IP "\fBhelp\fP"
+Produces help, either for all commands or if given a command name then the help
+for that particular command\&.
+.IP
+.PP
+.SH "GENERAL OPTIONS"
+Most command line options can be set using the configuration file as
+well and the descriptions indicate the necessary configuration option
+to set\&.
+.PP 
+.IP "\fB\-h, \-\-help\fP"
+Help; display a help message and then quit\&.
+.IP "\fB\-y, \-\-assumeyes\fP"
+Assume yes; assume that the answer to any question which would be asked 
+is yes\&.
+.br
+Configuration Option: \fBassumeyes\fP
+.IP "\fB\-\-assumeno\fP"
+Assume no; assume that the answer to any question which would be asked 
+is no\&. This option overrides assumeyes, but is still subject to alwaysprompt.
+.br
+Configuration Option: \fBassumeno\fP
+.IP "\fB\-c, \-\-config=[config file]\fP" 
+Specifies the config file location - can take HTTP and FTP URLs and local file
+paths\&.
+.br
+.IP "\fB\-q, \-\-quiet\fP" 
+Run without output.  Note that you likely also want to use \-y\&.
+.br
+.IP "\fB\-v, \-\-verbose\fP" 
+Run with a lot of debugging output\&.
+.br
+.IP "\fB\-d, \-\-debuglevel=[number]\fP" 
+Sets the debugging level to [number] \- turns up or down the amount of things that are printed\&. Practical range: 0 - 10
+.br
+Configuration Option: \fBdebuglevel\fP
+.IP "\fB\-e, \-\-errorlevel=[number]\fP" 
+Sets the error level to [number] Practical range 0 \- 10. 0 means print only critical errors about which you must be told. 1 means print all errors, even ones that are not overly important. 1+ means print more errors (if any) \-e 0 is good for cron jobs.
+.br
+Configuration Option: \fBerrorlevel\fP
+.IP "\fB\-\-rpmverbosity=[name]\fP" 
+Sets the debug level to [name] for rpm scriptlets. 'info' is the default, other
+options are: 'critical', 'emergency', 'error', 'warn' and 'debug'.
+.br
+Configuration Option: \fBrpmverbosity\fP
+.IP "\fB\-R, \-\-randomwait=[time in minutes]\fP" 
+Sets the maximum amount of time yum will wait before performing a command \- it randomizes over the time.
+.IP "\fB\-C, \-\-cacheonly\fP" 
+Tells yum to run entirely from system cache; does not download or update
+metadata.
+When this is used by a non\-root user, yum will run entirely from user cache in
+$TMPDIR.
+This option doesn't stop yum from updating user cache from system cache locally
+if the latter is newer (this is always done when running as a user).
+.IP "\fB\-\-version\fP" 
+Reports the \fByum\fP version number and installed package versions for
+everything in history_record_packages (can be added to by plugins).
+.IP "\fB\-\-showduplicates\fP" 
+Doesn't limit packages to their latest versions in the info, list and search
+commands (will also affect plugins which use the doPackageLists() API).
+.IP "\fB\-\-installroot=root\fP" 
+Specifies an alternative installroot, relative to which all packages will be
+installed. Think of this like doing "chroot <root> yum" except using
+\-\-installroot allows yum to work before the chroot is created.
+Note: You may also want to use the option \-\-releasever=/ when creating the
+installroot as otherwise the $releasever value is taken from the rpmdb within
+the installroot (and thus. will be empty, before creation).
+.br
+Configuration Option: \fBinstallroot\fP
+.IP "\fB\-\-enablerepo=repoidglob\fP"
+Enables specific repositories by id or glob that have been disabled in the 
+configuration file using the enabled=0 option.
+.br
+Configuration Option: \fBenabled\fP
+.IP "\fB\-\-disablerepo=repoidglob\fP"
+Disables specific repositories by id or glob. 
+.br
+Configuration Option: \fBenabled\fP
+.IP "\fB\-\-obsoletes\fP"
+This option only has affect for an update, it enables \fByum\fP\'s obsoletes
+processing logic. For more information see the \fBupdate\fP command above.
+.br
+Configuration Option: \fBobsoletes\fP
+.IP "\fB\-x, \-\-exclude=package\fP"
+Exclude a specific package by name or glob from all repositories, so yum works
+as if that package was never in the repositories.
+This is commonly used so a package isn't upgraded or installed accidentally, but
+can be used to remove packages in any way that "yum list" will show packages.
+
+Can be disabled using --disableexcludes.
+Configuration Option: \fBexclude\fP, \fBincludepkgs\fP
+.br
+.IP "\fB\-\-color=[always|auto|never]\fP"
+Display colorized output automatically, depending on the output terminal,
+always (using ANSI codes) or never. Note that some commands (Eg. list and info)
+will do a little extra work when color is enabled.
+Configuration Option: \fBcolor\fP
+.br
+.IP "\fB\-\-disableexcludes=[all|main|repoid]\fP"
+Disable the excludes defined in your config files. Takes one of three options:
+.br
+all == disable all excludes
+.br
+main == disable excludes defined in [main] in yum.conf
+.br
+repoid == disable excludes defined for that repo
+.br
+.IP "\fB\-\-disableincludes=[all|repoid]\fP"
+Disable the includes defined in your config files. Takes one of two options:
+.br
+all == disable all includes
+.br
+repoid == disable includes defined for that repo
+.br
+.IP "\fB\-\-disableplugin=plugin\fP"
+Run with one or more plugins disabled, the argument is a comma separated list
+of wildcards to match against plugin names.
+.br
+.IP "\fB\-\-noplugins\fP"
+Run with all plugins disabled.
+.br
+Configuration Option: \fBplugins\fP
+.IP "\fB\-\-nogpgcheck\fP"
+Run with GPG signature checking disabled.
+.br
+Configuration Option: \fBgpgcheck\fP
+.IP "\fB\-\-skip\-broken\fP"
+Resolve depsolve problems by removing packages that are causing problems
+from the transaction.
+.br
+Configuration Option: \fBskip_broken\fP
+.br
+.IP "\fB\-\-releasever=version\fP"
+Pretend the current release version is the given string. This is very useful
+when combined with \-\-installroot. You can also use \-\-releasever=/ to take
+the releasever information from outside the installroot.
+Note that with the default upstream cachedir, of /var/cache/yum, using this
+option will corrupt your cache (and you can use $releasever in your cachedir
+configuration to stop this).
+.PP 
+.IP "\fB\-t, \-\-tolerant\fP"
+This option makes yum go slower, checking for things that shouldn't be possible
+making it more tolerant of external errors.
+.br
+.IP "\fB\-\-downloadonly\fP"
+Don't update, just download. This is done in the background, so the yum lock is released for other operations. This can also be chosen by typing 'd'ownloadonly
+at the transaction confirmation prompt.
+.br
+.IP "\fB\-\-downloaddir=directory\fP"
+Specifies an alternate directory to store packages.
+.br
+.IP "\fB\-\-setopt=option=value\fP"
+Set any config option in yum config or repo files. For options in the global 
+config just use: \-\-setopt=option=value for repo options use: \-\-setopt=repoid.option=value
+.PP
+.IP "\fB\-\-security\fP"
+This option includes packages that say they fix a security issue, in updates.
+.br
+.IP "\fB\--advisory=ADVS, --advisories=ADVS\fP"
+This option includes in updates packages corresponding to the advisory ID, Eg. FEDORA-2201-123.
+.IP "\fB\--bz=BZS\fP"
+This option includes in updates packages that say they fix a Bugzilla ID, Eg. 123.
+.IP "\fB\--cve=CVES\fP"
+This option includes in updates packages that say they fix a CVE - Common Vulnerabilities and Exposures ID (http://cve.mitre.org/about/), Eg. CVE-2201-0123.
+.IP "\fB\--bugfix\fP"
+This option includes in updates packages that say they fix a bugfix issue.
+.IP "\fB\--sec-severity=SEVS, --secseverity=SEVS\fP"
+This option includes in updates security relevant packages of the specified severity.
+
+
+.SH "LIST OPTIONS"
+The following are the ways which you can invoke \fByum\fP in list
+mode\&.  Note that all \fBlist\fP commands include information on the
+version of the package\&.
+.IP
+.IP "\fBOUTPUT\fP"
+
+
+The format of the output of yum list is:
+
+name.arch [epoch:]version-release  repo or @installed-from-repo
+
+Note that if the repo cannot be determined, "installed" is printed instead.
+
+.IP "\fByum list [all | glob_exp1] [glob_exp2] [\&.\&.\&.]\fP"
+List all available and installed packages\&.
+.IP "\fByum list available [glob_exp1] [\&.\&.\&.]\fP"
+List all packages in the yum repositories available to be installed\&.
+.IP 
+.IP "\fByum list updates [glob_exp1] [\&.\&.\&.]\fP"
+List all packages with updates available in the yum repositories\&.
+.IP 
+.IP "\fByum list installed [glob_exp1] [\&.\&.\&.]\fP"
+List the packages specified by \fIargs\fP\&.  If an argument does not
+match the name of an available package, it is assumed to be a
+shell\-style glob and any matches are printed\&.
+.IP
+.IP "\fByum list extras [glob_exp1] [\&.\&.\&.]\fP"
+List the packages installed on the system that are not available in any yum
+repository listed in the config file.
+.IP
+.IP "\fByum list distro-extras [glob_exp1] [\&.\&.\&.]\fP"
+List the packages installed on the system that are not available, by name,
+in any yum repository listed in the config file.
+.IP
+.IP "\fByum list obsoletes [glob_exp1] [\&.\&.\&.]\fP"
+List the packages installed on the system that are obsoleted by packages
+in any yum repository listed in the config file.
+.IP
+.IP "\fByum list recent\fP"
+List packages recently added into the repositories. This is often not helpful,
+but what you may really want to use is "yum updateinfo list new" although that
+relies on updateinfo data from the repos.
+.IP
+
+.PP
+.SH "SPECIFYING PACKAGE NAMES"
+A package can be referred to for install, update, remove, list, info etc 
+with any of the following as well as globs of any of the following:
+.IP
+.br
+\fBname\fP
+.br
+\fBname.arch\fP
+.br
+\fBname-ver\fP
+.br
+\fBname-ver-rel\fP
+.br
+\fBname-ver-rel.arch\fP
+.br
+\fBname-epoch:ver-rel.arch\fP
+.br
+\fBepoch:name-ver-rel.arch\fP
+.IP
+For example: \fByum remove kernel-2.4.1-10.i686\fP
+     this will remove this specific kernel-ver-rel.arch.
+.IP
+Or:          \fByum list available 'foo*'\fP 
+     will list all available packages that match 'foo*'. (The single quotes will keep your shell from expanding the globs.)
+.IP
+.PP 
+.SH "CLEAN OPTIONS"
+The following are the ways which you can invoke \fByum\fP in clean mode.
+
+Note that these commands only operate on files in currently enabled
+repositories.
+If you use substitution variables (such as $releasever) in your \fBcachedir\fP
+configuration, the operation is further restricted to the current values of
+those variables.
+
+For fine-grained control over what is being cleaned, you can use
+\fB\-\-enablerepo\fP, \fB\-\-disablerepo\fP and \fB\-\-releasever\fP as
+desired.
+Note, however, that you cannot use \fB\-\-releasever='*'\fP to do the cleaning
+for all values previously used.
+Also note that untracked (no longer configured) repositories will not be
+automatically cleaned.
+
+To purge the entire cache in one go, the easiest way is to delete the files
+manually.
+Depending on your \fBcachedir\fP configuration, this usually means treating any
+variables as shell wildcards and recursively removing matching directories.
+For example, if your \fBcachedir\fP is /var/cache/yum/$basearch/$releasever,
+then the whole /var/cache/yum directory has to be removed.
+If you do this, \fByum\fP will rebuild the cache as required the next time it
+is run (this may take a while).
+
+As a convenience, when you run \fByum clean all\fP, a recursive lookup will be
+done to detect any repositories not cleaned due to the above restrictions.
+If some are found, a message will be printed stating how much disk space they
+occupy and thus how much you can reclaim by cleaning them.
+If you also supply \fB\-\-verbose\fP, a more detailed breakdown will be
+printed.
+
+.IP "\fByum clean expire-cache\fP"
+Eliminate the local data saying when the metadata and mirrorlists were downloaded for each repo. This means yum will revalidate the cache for each repo. next time it is used. However if the cache is still valid, nothing significant was deleted.
+
+.IP "\fByum clean packages\fP"
+Eliminate any cached packages from the system.  Note that packages are not automatically deleted after they are downloaded.
+
+.IP "\fByum clean headers\fP"
+Eliminate all of the header files, which old versions of yum used for
+dependency resolution.
+
+.IP "\fByum clean metadata\fP"
+Eliminate all of the files which yum uses to determine the remote
+availability of packages. Using this option will force yum to download all the 
+metadata the next time it is run.
+
+.IP "\fByum clean dbcache\fP"
+Eliminate the sqlite cache used for faster access to metadata.
+Using this option will force yum to download the sqlite metadata the next time
+it is run, or recreate the sqlite metadata if using an older repo.
+
+.IP "\fByum clean rpmdb\fP"
+Eliminate any cached data from the local rpmdb.
+
+.IP "\fByum clean plugins\fP"
+Tell any enabled plugins to eliminate their cached data.
+
+.IP "\fByum clean all\fP"
+Does all of the above.
+
+.SH "EXAMPLES"
+.PP
+To list all updates that are security relevant, and get a return code on whether there are security updates use:
+.IP
+yum --security check-update
+.PP
+To upgrade packages that have security errata (upgrades to the latest
+available package) use:
+.IP
+yum --security update
+.PP
+To upgrade packages that have security errata (upgrades to the last
+security errata package) use:
+.IP
+yum --security update-minimal
+.PP
+To get a list of all BZs that are fixed for packages you have installed use:
+.IP
+yum updateinfo list bugzillas
+.PP
+To get a list of all security advisories, including the ones you have already
+installed use:
+.IP
+yum updateinfo list all security
+.PP
+To get the information on advisory FEDORA-2707-4567 use:
+.IP
+yum updateinfo info FEDORA-2707-4567
+.PP
+For Red Hat advisories, respin suffixes are also accepted in the ID, although
+they won't have any effect on the actual respin selected by yum, as it will
+always select the latest one available.  For example, if you use:
+.IP
+yum updateinfo info RHSA-2016:1234-2
+.PP
+while RHSA-2016:1234-3 has been shipped already, yum will select the latter
+(provided your updateinfo.xml is current).  The same would happen if you just
+specified RHSA-2016:1234.  That said, there's no need for you to specify or
+care about the suffix at all.
+.PP
+To update packages to the latest version which contain fixes for Bugzillas 123, 456 and 789; and all security updates use:
+.IP
+yum --bz 123 --bz 456 --bz 789 --security update
+.PP
+To update to the packages which just update Bugzillas 123, 456 and 789; and all security updates use:
+.IP
+yum --bz 123 --bz 456 --bz 789 --security update-minimal
+.PP
+To get an info list of the latest packages which contain fixes for Bugzilla 123; CVEs CVE-2207-0123 and CVE-2207-3210; and Fedora advisories FEDORA-2707-4567 and FEDORA-2707-7654 use:
+.IP
+yum --bz 123 --cve CVE-2207-0123 --cve CVE-2207-3210 --advisory FEDORA-2707-4567 --advisory FEDORA-2707-7654 info updates
+.PP
+To get a list of packages which are "new".
+.IP
+yum updateinfo list new
+.PP
+To get a summary of advisories you haven't installed yet use:
+.IP
+yum updateinfo summary
+
+
+.PP 
+.SH "PLUGINS"
+Yum can be extended through the use of plugins. A plugin is a Python ".py" file
+which is installed in one of the directories specified by the \fBpluginpath\fP
+option in yum.conf. For a plugin to work, the following conditions must be met:
+.LP
+1. The plugin module file must be installed in the plugin path as just
+described.
+.LP
+2. The global \fBplugins\fP option in /etc/yum/yum.conf must be set to `1'.
+.LP
+3. A configuration file for the plugin must exist in
+/etc/yum/pluginconf.d/<plugin_name>.conf and the \fBenabled\fR setting in this
+file must set to `1'. The minimal content for such a configuration file is:
+.IP
+[main]
+.br
+enabled = 1
+.LP
+See the \fByum.conf(5)\fR man page for more information on plugin related
+configuration options.
+
+.PP
+.SH "FILES"
+.nf
+/etc/yum/yum.conf
+/etc/yum/version-groups.conf
+/etc/yum/repos.d/
+/etc/yum/pluginconf.d/
+/var/cache/yum/
+.fi 
+
+.PP
+.SH "SEE ALSO"
+.nf
+.I pkcon (1)
+.I yum.conf (5)
+.I yum-updatesd (8)
+.I package-cleanup (1)
+.I repoquery (1)
+.I yum-complete-transaction (1)
+.I yumdownloader (1)
+.I yum-utils (1)
+.I yum-langpacks (1)
+http://yum.baseurl.org/
+http://yum.baseurl.org/wiki/Faq
+yum search yum
+.fi
+
+.PP
+.SH "AUTHORS"
+.nf
+See the Authors file included with this program.
+.fi
+
+.PP
+.SH "BUGS"
+There of course aren't any bugs, but if you find any, you should first
+consult the FAQ mentioned above and then email the mailing list:
+yum@lists.baseurl.org or filed in bugzilla.
+.fi


### PR DESCRIPTION
As discussed in #7, this adds the real yum man page.  I went ahead and included all the related yum man pages.  These are all directly from the upstream repo.

- https://github.com/rpm-software-management/yum/blob/master/docs/yum.8
- https://github.com/rpm-software-management/yum/blob/master/docs/yum.conf.5
- https://github.com/rpm-software-management/yum/blob/master/docs/yum-cron.8
- https://github.com/rpm-software-management/yum/blob/master/docs/yum-updatesd.8
- https://github.com/rpm-software-management/yum/blob/master/docs/yum-updatesd.conf.5

